### PR TITLE
Add possibility to add custom properties to theme.properties file

### DIFF
--- a/src/bin/build-keycloak-theme/build-keycloak-theme.ts
+++ b/src/bin/build-keycloak-theme/build-keycloak-theme.ts
@@ -19,6 +19,7 @@ export function main() {
     console.log("🔏 Building the keycloak theme...⌚");
 
     const extraPagesId: string[] = (parsedPackageJson as any)["keycloakify"]?.["extraPages"] ?? [];
+    const extraThemeProperties: string[] = (parsedPackageJson as any)["keycloakify"]?.["extraThemeProperties"] ?? [];
 
     generateKeycloakThemeResources({
         keycloakThemeBuildingDirPath,
@@ -55,7 +56,8 @@ export function main() {
             };
 
         })(),
-        extraPagesId
+        extraPagesId,
+        extraThemeProperties
     });
 
     const { jarFilePath } = generateJavaStackFiles({

--- a/src/bin/build-keycloak-theme/generateKeycloakThemeResources.ts
+++ b/src/bin/build-keycloak-theme/generateKeycloakThemeResources.ts
@@ -23,12 +23,13 @@ export function generateKeycloakThemeResources(
         //If urlOrigin is not undefined then it means --externals-assets
         urlOrigin: undefined | string;
         extraPagesId: string[];
+        extraThemeProperties: string[];
     }
 ) {
 
     const { 
         themeName, reactAppBuildDirPath, keycloakThemeBuildingDirPath, 
-        urlPathname, urlOrigin, extraPagesId
+        urlPathname, urlOrigin, extraPagesId, extraThemeProperties
     } = params;
 
     const themeDirPath = pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "theme", themeName, "login");
@@ -166,7 +167,10 @@ export function generateKeycloakThemeResources(
 
     fs.writeFileSync(
         pathJoin(themeDirPath, "theme.properties"),
-        Buffer.from("parent=keycloak", "utf8")
+        Buffer.from(
+            "parent=keycloak".concat("\n\n", extraThemeProperties.join("\n\n")),
+            "utf8"
+        )
     );
 
 }

--- a/src/test/bin/generateKeycloakThemeResources.ts
+++ b/src/test/bin/generateKeycloakThemeResources.ts
@@ -14,6 +14,7 @@ generateKeycloakThemeResources({
     "keycloakThemeBuildingDirPath": pathJoin(sampleReactProjectDirPath, "build_keycloak_theme"),
     "urlPathname": "/keycloakify-demo-app/",
     "urlOrigin": undefined,
-    "extraPagesId": ["my-custom-page.ftl"]
+    "extraPagesId": ["my-custom-page.ftl"],
+    "extraThemeProperties": ["env=test"]
 });
 


### PR DESCRIPTION
Right now upon generation of the `theme.properties` only `parent=keycloak` is added inside.

In our use case, we need to add some custom value pairs there (e.g. `env=dev`). Added some code to enable it.

Cheers!