### PR TITLE
fix(mvn): scoped packages compatibility

### DIFF
--- a/src/bin/build-keycloak-theme/generateDebugFiles/generateDebugFiles.ts
+++ b/src/bin/build-keycloak-theme/generateDebugFiles/generateDebugFiles.ts
@@ -7,12 +7,12 @@ export const containerLaunchScriptBasename = "start_keycloak_testing_container.s
 /** Files for being able to run a hot reload keycloak container */
 export function generateDebugFiles(
     params: {
-        packageJsonName: string;
+        themeName: string;
         keycloakThemeBuildingDirPath: string;
     }
 ) {
 
-    const { packageJsonName, keycloakThemeBuildingDirPath } = params;
+    const { themeName, keycloakThemeBuildingDirPath } = params;
 
     fs.writeFileSync(
         pathJoin(keycloakThemeBuildingDirPath, "Dockerfile"),
@@ -32,7 +32,7 @@ export function generateDebugFiles(
         )
     );
 
-    const dockerImage = `${packageJsonName}/keycloak-hot-reload`;
+    const dockerImage = `${themeName}/keycloak-hot-reload`;
     const containerName = "keycloak-testing-container";
 
     fs.writeFileSync(
@@ -52,8 +52,8 @@ export function generateDebugFiles(
                 `	--name ${containerName} \\`,
                 "	-e KEYCLOAK_USER=admin \\",
                 "	-e KEYCLOAK_PASSWORD=admin \\",
-                `	-v ${pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "theme", packageJsonName)
-                }:/opt/jboss/keycloak/themes/${packageJsonName}:rw \\`,
+                `	-v ${pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "theme", themeName)
+                }:/opt/jboss/keycloak/themes/${themeName}:rw \\`,
                 `	-it ${dockerImage}:latest`,
                 ""
             ].join("\n"),

--- a/src/bin/build-keycloak-theme/generateJavaStackFiles.ts
+++ b/src/bin/build-keycloak-theme/generateJavaStackFiles.ts
@@ -3,21 +3,20 @@ import * as url from "url";
 import * as fs from "fs";
 import { join as pathJoin, dirname as pathDirname } from "path";
 
-export type ParsedPackageJson = {
-    name: string;
-    version: string;
-    homepage?: string;
-};
 
 export function generateJavaStackFiles(
     params: {
-        parsedPackageJson: ParsedPackageJson;
+        version: string;
+        themeName: string;
+        homepage?: string;
         keycloakThemeBuildingDirPath: string;
     }
 ): { jarFilePath: string; } {
 
     const {
-        parsedPackageJson: { name, version, homepage },
+        themeName,
+        version,
+        homepage,
         keycloakThemeBuildingDirPath
     } = params;
 
@@ -28,7 +27,7 @@ export function generateJavaStackFiles(
 
             const groupId = (() => {
 
-                const fallbackGroupId = `there.was.no.homepage.field.in.the.package.json.${name}`;
+                const fallbackGroupId = `there.was.no.homepage.field.in.the.package.json.${themeName}`;
 
                 return (!homepage ?
                     fallbackGroupId :
@@ -37,7 +36,7 @@ export function generateJavaStackFiles(
 
             })();
 
-            const artefactId = `${name}-keycloak-theme`;
+            const artefactId = `${themeName}-keycloak-theme`;
 
             const pomFileCode = [
                 `<?xml version="1.0"?>`,
@@ -83,7 +82,7 @@ export function generateJavaStackFiles(
                 JSON.stringify({
                     "themes": [
                         {
-                            "name": name,
+                            "name": themeName,
                             "types": ["login"]
                         }
                     ]
@@ -94,7 +93,7 @@ export function generateJavaStackFiles(
 
     }
 
-    return { "jarFilePath": pathJoin(keycloakThemeBuildingDirPath, "target", `${name}-${version}.jar`) };
+    return { "jarFilePath": pathJoin(keycloakThemeBuildingDirPath, "target", `${themeName}-${version}.jar`) };
 
 }
 


### PR DESCRIPTION
Pom generated for scoped packages like `@scope/package` is malformed. Artifact id is generated using `package.json` name field, being an invalid pattern.

```
[ERROR] 'artifactId' with value '@scope/package' does not match a valid id pattern.
```

This PR sanitizes package name for using `scope-package` instead.