### PR TITLE
Adding name field to realm in KcContext type

### DIFF
--- a/src/lib/getKcContext/KcContextBase.ts
+++ b/src/lib/getKcContext/KcContextBase.ts
@@ -34,6 +34,7 @@ export declare namespace KcContextBase {
             loginUrl: string;
         };
         realm: {
+            name: string;
             displayName?: string;
             displayNameHtml?: string;
             internationalizationEnabled: boolean;


### PR DESCRIPTION
This PR adds the `name` field to the realm object in the KcContext Common type that is already being sent to the theme but wasn't declared, causing a compilation error when used.

<img width="477" alt="image" src="https://user-images.githubusercontent.com/6564471/146933292-ca0b1bcc-9a9e-4348-98f5-bf0107df36c9.png">

I'm sending this PR directly because the fix seemed easy enough, but please let me know if there's something I misunderstood or missed 