### PR TITLE
Added realm name field to KcContext mocks object

### DIFF
--- a/src/lib/getKcContext/kcContextMocks/kcContextMocks.ts
+++ b/src/lib/getKcContext/kcContextMocks/kcContextMocks.ts
@@ -18,6 +18,7 @@ export const kcContextCommonMock: KcContextBase.Common = {
         "loginUrl": "/auth/realms/myrealm/login-actions/authenticate?client_id=account&tab_id=HoAx28ja4xg",
     },
     "realm": {
+        "name": "myrealm",
         "displayName": "myrealm",
         "displayNameHtml": "myrealm",
         "internationalizationEnabled": true,


### PR DESCRIPTION
PR https://github.com/InseeFrLab/keycloakify/pull/69 broke build because KcContext mock didn't create the realm name field. This PR fixes the issue.

Sorry about that 😰 