### PR TITLE
pass locale to getGetErrors to get correct messages

### DIFF
--- a/src/lib/useFormValidationSlice.tsx
+++ b/src/lib/useFormValidationSlice.tsx
@@ -313,6 +313,9 @@ export function useFormValidationSlice(params: {
         };
         passwordRequired: boolean;
         realm: { registrationEmailAsUsername: boolean };
+        locale?: {
+            currentLanguageTag: KcLanguageTag;
+        };
     };
     /** NOTE: Try to avoid passing a new ref every render for better performances. */
     passwordValidators?: Validators;
@@ -382,6 +385,7 @@ export function useFormValidationSlice(params: {
             "profile": {
                 "attributes": attributesWithPassword,
             },
+            "locale": kcContext.locale,
         },
     });
 


### PR DESCRIPTION
Pass locale to getErrors for getting currect error messages on validation. Now, if you open register page on `https://datalab.sspcloud.fr/home` switch to franch, write `aa` on `Nom d'utilisateur`, press tab, you will see error on english.