### PR TITLE
feat: add logout-confirm

### DIFF
--- a/src/bin/build-keycloak-theme/generateFtl/generateFtl.ts
+++ b/src/bin/build-keycloak-theme/generateFtl/generateFtl.ts
@@ -5,6 +5,7 @@ import { join as pathJoin } from "path";
 import { objectKeys } from "tsafe/objectKeys";
 import { ftlValuesGlobalName } from "../ftlValuesGlobalName";
 
+// https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/forms/login/freemarker/Templates.java
 export const pageIds = [
     "login.ftl",
     "register.ftl",
@@ -21,6 +22,7 @@ export const pageIds = [
     "login-idp-link-email.ftl",
     "login-page-expired.ftl",
     "login-config-totp.ftl",
+    "logout-confirm.ftl",
 ] as const;
 
 export type PageId = typeof pageIds[number];

--- a/src/lib/components/KcApp.tsx
+++ b/src/lib/components/KcApp.tsx
@@ -16,6 +16,7 @@ import { LoginIdpLinkConfirm } from "./LoginIdpLinkConfirm";
 import { LoginPageExpired } from "./LoginPageExpired";
 import { LoginIdpLinkEmail } from "./LoginIdpLinkEmail";
 import { LoginConfigTotp } from "./LoginConfigTotp";
+import { LogoutConfirm } from "./LogoutConfirm";
 
 export const KcApp = memo(({ kcContext, ...props }: { kcContext: KcContextBase } & KcProps) => {
     switch (kcContext.pageId) {
@@ -49,5 +50,7 @@ export const KcApp = memo(({ kcContext, ...props }: { kcContext: KcContextBase }
             return <LoginPageExpired {...{ kcContext, ...props }} />;
         case "login-config-totp.ftl":
             return <LoginConfigTotp {...{ kcContext, ...props }} />;
+        case "logout-confirm.ftl":
+            return <LogoutConfirm {...{ kcContext, ...props }} />;
     }
 });

--- a/src/lib/components/LogoutConfirm.tsx
+++ b/src/lib/components/LogoutConfirm.tsx
@@ -18,12 +18,10 @@ export const LogoutConfirm = memo(({ kcContext, ...props }: { kcContext: KcConte
             {...{ kcContext, ...props }}
             doFetchDefaultThemeResources={true}
             displayMessage={false}
-            /*@ts-ignore*/
             headerNode={msg("logoutConfirmTitle")}
             formNode={
                 <>
                     <div id="kc-logout-confirm" className="content-area">
-                        {/* @ts-ignore */}
                         <p className="instruction">{msg("logoutConfirmHeader")}</p>
                         <form className="form-actions" action={url.logoutConfirmAction} method="POST">
                             <input type="hidden" name="session_code" value={logoutConfirm.code} />
@@ -43,7 +41,6 @@ export const LogoutConfirm = memo(({ kcContext, ...props }: { kcContext: KcConte
                                         name="confirmLogout"
                                         id="kc-logout"
                                         type="submit"
-                                        /*@ts-ignore*/
                                         value={msgStr("doLogout")}
                                     />
                                 </div>

--- a/src/lib/components/LogoutConfirm.tsx
+++ b/src/lib/components/LogoutConfirm.tsx
@@ -1,0 +1,64 @@
+import { memo } from "react";
+import { useCssAndCx } from "tss-react";
+
+import { Template } from "./Template";
+import type { KcProps } from "./KcProps";
+import type { KcContextBase } from "../getKcContext/KcContextBase";
+import { getMsg } from "../i18n";
+
+export const LogoutConfirm = memo(({ kcContext, ...props }: { kcContext: KcContextBase.LogoutConfirm } & KcProps) => {
+    const { url, client, logoutConfirm } = kcContext;
+
+    const { cx } = useCssAndCx();
+
+    const { msg, msgStr } = getMsg(kcContext);
+
+    return (
+        <Template
+            {...{ kcContext, ...props }}
+            doFetchDefaultThemeResources={true}
+            displayMessage={false}
+            /*@ts-ignore*/
+            headerNode={msg("logoutConfirmTitle")}
+            formNode={
+                <>
+                    <div id="kc-logout-confirm" className="content-area">
+                        {/* @ts-ignore */}
+                        <p className="instruction">{msg("logoutConfirmHeader")}</p>
+                        <form className="form-actions" action={url.logoutConfirmAction} method="POST">
+                            <input type="hidden" name="session_code" value={logoutConfirm.code} />
+                            <div className={cx(props.kcFormGroupClass)}>
+                                <div id="kc-form-options">
+                                    <div className={cx(props.kcFormOptionsWrapperClass)}></div>
+                                </div>
+                                <div id="kc-form-buttons" className={cx(props.kcFormGroupClass)}>
+                                    <input
+                                        tabIndex={4}
+                                        className={cx(
+                                            props.kcButtonClass,
+                                            props.kcButtonPrimaryClass,
+                                            props.kcButtonBlockClass,
+                                            props.kcButtonLargeClass,
+                                        )}
+                                        name="confirmLogout"
+                                        id="kc-logout"
+                                        type="submit"
+                                        /*@ts-ignore*/
+                                        value={msgStr("doLogout")}
+                                    />
+                                </div>
+                            </div>
+                        </form>
+                        <div id="kc-info-message">
+                            {!logoutConfirm.skipLink && client.baseUrl && (
+                                <p>
+                                    <a href={client.baseUrl} dangerouslySetInnerHTML={{ __html: msgStr("backToApplication") }} />
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                </>
+            }
+        />
+    );
+});

--- a/src/lib/getKcContext/KcContextBase.ts
+++ b/src/lib/getKcContext/KcContextBase.ts
@@ -25,7 +25,8 @@ export type KcContextBase =
     | KcContextBase.LoginIdpLinkConfirm
     | KcContextBase.LoginIdpLinkEmail
     | KcContextBase.LoginPageExpired
-    | KcContextBase.LoginConfigTotp;
+    | KcContextBase.LoginConfigTotp
+    | KcContextBase.LogoutConfirm;
 
 export declare namespace KcContextBase {
     export type Common = {
@@ -254,6 +255,20 @@ export declare namespace KcContextBase {
             manualUrl: string;
             totpSecret: string;
             otpCredentials: { id: string; userLabel: string }[];
+        };
+    };
+
+    export type LogoutConfirm = Common & {
+        pageId: "logout-confirm.ftl";
+        url: {
+            logoutConfirmAction: string;
+        };
+        client: {
+            baseUrl?: string;
+        };
+        logoutConfirm: {
+            code: string;
+            skipLink?: boolean;
         };
     };
 }

--- a/src/lib/getKcContext/kcContextMocks/kcContextMocks.ts
+++ b/src/lib/getKcContext/kcContextMocks/kcContextMocks.ts
@@ -411,4 +411,17 @@ export const kcContextMocks: KcContextBase[] = [
             },
         },
     }),
+    id<KcContextBase.LogoutConfirm>({
+        ...kcContextCommonMock,
+        "pageId": "logout-confirm.ftl",
+        "url": {
+            ...kcContextCommonMock.url,
+            "logoutConfirmAction": "Continuer?",
+        },
+        "client": {
+            "clientId": "myApp",
+            "baseUrl": "#",
+        },
+        "logoutConfirm": { "code": "123", skipLink: false },
+    }),
 ];

--- a/src/lib/i18n/generated_kcMessages/18.0.1/login.ts
+++ b/src/lib/i18n/generated_kcMessages/18.0.1/login.ts
@@ -2513,9 +2513,6 @@ export const kcMessages = {
         "noCertificate": "[Pas de certificat]",
         "pageNotFound": "Page non trouvée",
         "internalServerError": "Une erreur interne du serveur s'est produite",
-        "logoutConfirmTitle": "Déconnexion",
-        "logoutConfirmHeader": "Êtes-vous sûr(e) de vouloir vous déconnecter ?",
-        "doLogout": "Se déconnecter",
     },
     "hu": {
         "doLogIn": "Belépés",

--- a/src/lib/i18n/generated_kcMessages/18.0.1/login.ts
+++ b/src/lib/i18n/generated_kcMessages/18.0.1/login.ts
@@ -2513,6 +2513,9 @@ export const kcMessages = {
         "noCertificate": "[Pas de certificat]",
         "pageNotFound": "Page non trouvée",
         "internalServerError": "Une erreur interne du serveur s'est produite",
+        "logoutConfirmTitle": "Déconnexion",
+        "logoutConfirmHeader": "Êtes-vous sûr(e) de vouloir vous déconnecter ?",
+        "doLogout": "Se déconnecter",
     },
     "hu": {
         "doLogIn": "Belépés",

--- a/src/lib/i18n/index.tsx
+++ b/src/lib/i18n/index.tsx
@@ -20,11 +20,14 @@ export const kcMessages = {
     "fr": {
         ...kcMessagesBase["fr"],
         /* spell-checker: disable */
-        "shouldBeEqual": "{0} doit être egale à {1}",
+        "shouldBeEqual": "{0} doit être égal à {1}",
         "shouldBeDifferent": "{0} doit être différent de {1}",
         "shouldMatchPattern": "Dois respecter le schéma: `/{0}/`",
-        "mustBeAnInteger": "Doit être un nombre entiers",
+        "mustBeAnInteger": "Doit être un nombre entier",
         "notAValidOption": "N'est pas une option valide",
+        "logoutConfirmTitle": "Déconnexion",
+        "logoutConfirmHeader": "Êtes-vous sûr(e) de vouloir vous déconnecter ?",
+        "doLogout": "Se déconnecter",
         /* spell-checker: enable */
     },
 };


### PR DESCRIPTION
Bonjour, pour Keycloak 18, je souhaiterai ajouter la possibilité de thémer 
[logout-confirm.tfl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/login/logout-confirm.ftl)

La traduction française des nouveaux termes n'est pas encore dispo, y-a-t-il moyen de fournir une trad par défaut en FR pour les nouveaux termes (ex: `logoutConfirmTitle` ou `logoutConfirmHeader`), ou faut-il générer les fichiers pour la 
18.0.0 ?

