### PR TITLE
Avoiding superfluous downloads by not deleting the temporary keycloak download folder

### DIFF
--- a/src/bin/tools/downloadAndUnzip.ts
+++ b/src/bin/tools/downloadAndUnzip.ts
@@ -2,7 +2,7 @@ import { basename as pathBasename, join as pathJoin } from "path";
 import { execSync } from "child_process";
 import fs from "fs";
 import { transformCodebase } from "./transformCodebase";
-import { rm_rf, rm, rm_r } from "./rm";
+import { rm_rf } from "./rm";
 
 /** assert url ends with .zip */
 export function downloadAndUnzip(params: { url: string; destDirPath: string; pathOfDirToExtractInArchive?: string }) {
@@ -11,22 +11,20 @@ export function downloadAndUnzip(params: { url: string; destDirPath: string; pat
     const tmpDirPath = pathJoin(destDirPath, "..", "tmp_xxKdOxnEdx");
     const zipFilePath = pathBasename(url);
 
-    rm_rf(tmpDirPath);
+    if (!fs.existsSync(pathJoin(tmpDirPath, zipFilePath))) {
+        rm_rf(tmpDirPath);
 
-    fs.mkdirSync(tmpDirPath, { "recursive": true });
-
-    execSync(`curl -L ${url} -o ${zipFilePath}`, { "cwd": tmpDirPath });
+        fs.mkdirSync(tmpDirPath, { "recursive": true });
+        
+        execSync(`curl -L ${url} -o ${zipFilePath}`, { "cwd": tmpDirPath });
+    }
 
     execSync(`unzip -o ${zipFilePath}${pathOfDirToExtractInArchive === undefined ? "" : ` "${pathOfDirToExtractInArchive}/**/*"`}`, {
         "cwd": tmpDirPath,
     });
 
-    rm(pathBasename(url), { "cwd": tmpDirPath });
-
     transformCodebase({
         "srcDirPath": pathOfDirToExtractInArchive === undefined ? tmpDirPath : pathJoin(tmpDirPath, pathOfDirToExtractInArchive),
         destDirPath,
     });
-
-    rm_r(tmpDirPath);
 }


### PR DESCRIPTION
Hi !

I have been developing for a little while a user friendly keycloak theming service using your library. I've been really happy with it so far!

An issue I've found though, is that keycloakify downloads the same file over and over while it could be kept in cache. This simple commit avoids downloading the keycloak archive if it already exists. If it isn't found (for example because of a version bump in the new keycloakify version), the folder is deleted and the new archive is downloaded.

This increases the speed of the generation process and avoids failure from when github rejects repeated requests.

There could be optimization still, for instance by not unziping the archive, but this simple fix is already ample enough.