### PR TITLE
[FIX] Add attempt and recover to prevent ftl from crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@
 <p align="center">
     <i>Ultimately this build tool generates a Keycloak theme <a href="https://www.keycloakify.dev">Learn more</a></i>
     <img src="https://user-images.githubusercontent.com/6702424/110260457-a1c3d380-7fac-11eb-853a-80459b65626b.png">
-</p>  
+</p>
 
-> The official websites of the project are temporarily down. While it is being addressed, you can access the doc [here](https://github.com/InseeFrLab/keycloakify/tree/v5_docs).  
-
+> The official websites of the project are temporarily down. While it is being addressed, you can access the doc [here](https://github.com/InseeFrLab/keycloakify/tree/v5_docs).
 
 # Changelog highlights
 

--- a/src/bin/build-keycloak-theme/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/build-keycloak-theme/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -96,212 +96,215 @@ ${ftl_object_to_js_code_declaring_an_object(.data_model, [])?no_esc};
 
 })()
 <#function ftl_object_to_js_code_declaring_an_object object path>
-
-        <#local isHash = "">
         <#attempt>
-            <#local isHash = object?is_hash || object?is_hash_ex>
-        <#recover>
-            <#return "ABORT: Can't evaluate if " + path?join(".") + " is hash">
-        </#attempt>
-
-        <#if isHash>
-
-            <#if path?size gt 10>
-                <#return "ABORT: Too many recursive calls">
-            </#if>
-
-            <#local keys = "">
-
+            <#local isHash = "">
             <#attempt>
-                <#local keys = object?keys>
+                <#local isHash = object?is_hash || object?is_hash_ex>
             <#recover>
-                <#return "ABORT: We can't list keys on this object">
+                <#return "ABORT: Can't evaluate if " + path?join(".") + " is hash">
             </#attempt>
 
+            <#if isHash>
 
-            <#local out_seq = []>
-
-            <#list keys as key>
-
-                <#if ["class","declaredConstructors","superclass","declaringClass" ]?seq_contains(key) >
-                    <#continue>
+                <#if path?size gt 10>
+                    <#return "ABORT: Too many recursive calls">
                 </#if>
 
-                <#if 
-                    (
-                        ["loginUpdatePasswordUrl", "loginUpdateProfileUrl", "loginUsernameReminderUrl", "loginUpdateTotpUrl"]?seq_contains(key) && 
-                        are_same_path(path, ["url"])
-                    ) || (
-                        key == "updateProfileCtx" && 
-                        are_same_path(path, [])
-                    ) || (
-                        <#-- https://github.com/InseeFrLab/keycloakify/pull/65#issuecomment-991896344 (reports with saml-post-form.ftl) -->
-                        <#-- https://github.com/InseeFrLab/keycloakify/issues/91#issue-1212319466 (reports with error.ftl and Kc18) -->
-                        <#-- https://github.com/InseeFrLab/keycloakify/issues/109#issuecomment-1134610163 -->
-                        key == "loginAction" && 
-                        are_same_path(path, ["url"]) && 
-                        ["saml-post-form.ftl", "error.ftl", "info.ftl"]?seq_contains(pageId) &&
-                        !(auth?has_content && auth.showTryAnotherWayLink())
-                    ) || (
-                        ["contextData", "idpConfig", "idp", "authenticationSession"]?seq_contains(key) &&
-                        are_same_path(path, ["brokerContext"]) &&
-                        ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
-                    ) || (
-                        key == "identityProviderBrokerCtx" && 
-                        are_same_path(path, []) &&
-                        ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
-                    ) ||  (
-                        ["masterAdminClient", "delegateForUpdate", "defaultRole"]?seq_contains(key) &&
-                        are_same_path(path, ["realm"])
-                    )
-                >
-                    <#local out_seq += ["/*If you need '" + key + "' on " + pageId + ", please submit an issue to the Keycloakify repo*/"]>
-                    <#continue>
-                </#if>
+                <#local keys = "">
 
-                <#if key == "attemptedUsername" && are_same_path(path, ["auth"])>
+                <#attempt>
+                    <#local keys = object?keys>
+                <#recover>
+                    <#return "ABORT: We can't list keys on this object">
+                </#attempt>
+
+
+                <#local out_seq = []>
+
+                <#list keys as key>
+
+                    <#if ["class","declaredConstructors","superclass","declaringClass" ]?seq_contains(key) >
+                        <#continue>
+                    </#if>
+
+                    <#if
+                        (
+                            ["loginUpdatePasswordUrl", "loginUpdateProfileUrl", "loginUsernameReminderUrl", "loginUpdateTotpUrl"]?seq_contains(key) &&
+                            are_same_path(path, ["url"])
+                        ) || (
+                            key == "updateProfileCtx" &&
+                            are_same_path(path, [])
+                        ) || (
+                            <#-- https://github.com/InseeFrLab/keycloakify/pull/65#issuecomment-991896344 (reports with saml-post-form.ftl) -->
+                            <#-- https://github.com/InseeFrLab/keycloakify/issues/91#issue-1212319466 (reports with error.ftl and Kc18) -->
+                            <#-- https://github.com/InseeFrLab/keycloakify/issues/109#issuecomment-1134610163 -->
+                            key == "loginAction" &&
+                            are_same_path(path, ["url"]) &&
+                            ["saml-post-form.ftl", "error.ftl", "info.ftl"]?seq_contains(pageId) &&
+                            !(auth?has_content && auth.showTryAnotherWayLink())
+                        ) || (
+                            ["contextData", "idpConfig", "idp", "authenticationSession"]?seq_contains(key) &&
+                            are_same_path(path, ["brokerContext"]) &&
+                            ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
+                        ) || (
+                            key == "identityProviderBrokerCtx" &&
+                            are_same_path(path, []) &&
+                            ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
+                        ) ||  (
+                            ["masterAdminClient", "delegateForUpdate", "defaultRole"]?seq_contains(key) &&
+                            are_same_path(path, ["realm"])
+                        )
+                    >
+                        <#local out_seq += ["/*If you need '" + key + "' on " + pageId + ", please submit an issue to the Keycloakify repo*/"]>
+                        <#continue>
+                    </#if>
+
+                    <#if key == "attemptedUsername" && are_same_path(path, ["auth"])>
+
+                        <#attempt>
+                            <#-- https://github.com/keycloak/keycloak/blob/3a2bf0c04bcde185e497aaa32d0bb7ab7520cf4a/themes/src/main/resources/theme/base/login/template.ftl#L63 -->
+                            <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
+                                <#continue>
+                            </#if>
+                        <#recover>
+                        </#attempt>
+
+                    </#if>
 
                     <#attempt>
-                        <#-- https://github.com/keycloak/keycloak/blob/3a2bf0c04bcde185e497aaa32d0bb7ab7520cf4a/themes/src/main/resources/theme/base/login/template.ftl#L63 -->
-                        <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
+                        <#if !object[key]??>
                             <#continue>
                         </#if>
                     <#recover>
+                        <#local out_seq += ["/*Couldn't test if '" + key + "' is available on this object*/"]>
+                        <#continue>
                     </#attempt>
 
-                </#if>
-                
-                <#attempt>
-                    <#if !object[key]??>
+                    <#local propertyValue = "">
+
+                    <#attempt>
+                        <#local propertyValue = object[key]>
+                    <#recover>
+                        <#local out_seq += ["/*Couldn't dereference '" + key + "' on this object*/"]>
+                        <#continue>
+                    </#attempt>
+
+                    <#local rec_out = ftl_object_to_js_code_declaring_an_object(propertyValue, path + [ key ])>
+
+                    <#if rec_out?starts_with("ABORT:")>
+
+                        <#local errorMessage = rec_out?remove_beginning("ABORT:")>
+
+                        <#if errorMessage != " It's a method" >
+                            <#local out_seq += ["/*" + key + ": " + errorMessage + "*/"]>
+                        </#if>
+
                         <#continue>
                     </#if>
-                <#recover>
-                    <#local out_seq += ["/*Couldn't test if '" + key + "' is available on this object*/"]>
-                    <#continue>
-                </#attempt>
 
-                <#local propertyValue = "">
+                    <#local out_seq +=  ['"' + key + '": ' + rec_out + ","]>
 
-                <#attempt>
-                    <#local propertyValue = object[key]>
-                <#recover>
-                    <#local out_seq += ["/*Couldn't dereference '" + key + "' on this object*/"]>
-                    <#continue>
-                </#attempt>
+                </#list>
 
-                <#local rec_out = ftl_object_to_js_code_declaring_an_object(propertyValue, path + [ key ])>
+                <#return (["{"] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "}"])?join("\n")>
 
-                <#if rec_out?starts_with("ABORT:")>
+            </#if>
 
-                    <#local errorMessage = rec_out?remove_beginning("ABORT:")>
+            <#local isMethod = "">
+            <#attempt>
+                <#local isMethod = object?is_method>
+            <#recover>
+                <#return "ABORT: Can't test if it'sa method.">
+            </#attempt>
 
-                    <#if errorMessage != " It's a method" >
-                        <#local out_seq += ["/*" + key + ": " + errorMessage + "*/"]>
-                    </#if>
+            <#if isMethod>
 
-                    <#continue>
+                <#if are_same_path(path, ["auth", "showUsername"])>
+                    <#attempt>
+                        <#return auth.showUsername()?c>
+                    <#recover>
+                        <#return "ABORT: Couldn't evaluate auth.showUsername()">
+                    </#attempt>
                 </#if>
 
-                <#local out_seq +=  ['"' + key + '": ' + rec_out + ","]>
-
-            </#list>
-
-            <#return (["{"] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "}"])?join("\n")>
-
-        </#if>
-
-        <#local isMethod = "">
-        <#attempt>
-            <#local isMethod = object?is_method>
-        <#recover>
-            <#return "ABORT: Can't test if it'sa method.">
-        </#attempt>
-
-        <#if isMethod>
-
-            <#if are_same_path(path, ["auth", "showUsername"])>
-                <#attempt>
-                    <#return auth.showUsername()?c>
-                <#recover>
-                    <#return "ABORT: Couldn't evaluate auth.showUsername()">
-                </#attempt>
-            </#if>
-
-            <#if are_same_path(path, ["auth", "showResetCredentials"])>
-                <#attempt>
-                    <#return auth.showResetCredentials()?c>
-                <#recover>
-                    <#return "ABORT: Couldn't evaluate auth.showResetCredentials()">
-                </#attempt>
-            </#if>
-
-            <#if are_same_path(path, ["auth", "showTryAnotherWayLink"])>
-                <#attempt>
-                    <#return auth.showTryAnotherWayLink()?c>
-                <#recover>
-                    <#return "ABORT: Couldn't evaluate auth.showTryAnotherWayLink()">
-                </#attempt>
-            </#if>
-
-            <#return "ABORT: It's a method">
-        </#if>
-
-        <#local isBoolean = "">
-        <#attempt>
-            <#local isBoolean = object?is_boolean>
-        <#recover>
-            <#return "ABORT: Can't test if it's a boolean">
-        </#attempt>
-
-        <#if isBoolean>
-            <#return object?c>
-        </#if>
-
-        <#local isEnumerable = "">
-        <#attempt>
-            <#local isEnumerable = object?is_enumerable>
-        <#recover>
-            <#return "ABORT: Can't test if it's an enumerable">
-        </#attempt>
-
-
-        <#if isEnumerable>
-
-            <#local out_seq = []>
-
-            <#local i = 0>
-
-            <#list object as array_item>
-
-                <#local rec_out = ftl_object_to_js_code_declaring_an_object(array_item, path + [ i ])>
-
-                <#local i = i + 1>
-
-                <#if rec_out?starts_with("ABORT:")>
-
-                    <#local errorMessage = rec_out?remove_beginning("ABORT:")>
-
-                    <#if errorMessage != " It's a method" >
-                        <#local out_seq += ["/*" + i?string + ": " + errorMessage + "*/"]>
-                    </#if>
-
-                    <#continue>
+                <#if are_same_path(path, ["auth", "showResetCredentials"])>
+                    <#attempt>
+                        <#return auth.showResetCredentials()?c>
+                    <#recover>
+                        <#return "ABORT: Couldn't evaluate auth.showResetCredentials()">
+                    </#attempt>
                 </#if>
 
-                <#local out_seq += [rec_out + ","]>
+                <#if are_same_path(path, ["auth", "showTryAnotherWayLink"])>
+                    <#attempt>
+                        <#return auth.showTryAnotherWayLink()?c>
+                    <#recover>
+                        <#return "ABORT: Couldn't evaluate auth.showTryAnotherWayLink()">
+                    </#attempt>
+                </#if>
 
-            </#list>
+                <#return "ABORT: It's a method">
+            </#if>
 
-            <#return (["["] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "]"])?join("\n")>
+            <#local isBoolean = "">
+            <#attempt>
+                <#local isBoolean = object?is_boolean>
+            <#recover>
+                <#return "ABORT: Can't test if it's a boolean">
+            </#attempt>
 
-        </#if>
+            <#if isBoolean>
+                <#return object?c>
+            </#if>
 
-        <#attempt>
-            <#return '"' + object?js_string + '"'>;
+            <#local isEnumerable = "">
+            <#attempt>
+                <#local isEnumerable = object?is_enumerable>
+            <#recover>
+                <#return "ABORT: Can't test if it's an enumerable">
+            </#attempt>
+
+
+            <#if isEnumerable>
+
+                <#local out_seq = []>
+
+                <#local i = 0>
+
+                <#list object as array_item>
+
+                    <#local rec_out = ftl_object_to_js_code_declaring_an_object(array_item, path + [ i ])>
+
+                    <#local i = i + 1>
+
+                    <#if rec_out?starts_with("ABORT:")>
+
+                        <#local errorMessage = rec_out?remove_beginning("ABORT:")>
+
+                        <#if errorMessage != " It's a method" >
+                            <#local out_seq += ["/*" + i?string + ": " + errorMessage + "*/"]>
+                        </#if>
+
+                        <#continue>
+                    </#if>
+
+                    <#local out_seq += [rec_out + ","]>
+
+                </#list>
+
+                <#return (["["] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "]"])?join("\n")>
+
+            </#if>
+
+            <#attempt>
+                <#return '"' + object?js_string + '"'>;
+            <#recover>
+            </#attempt>
+
+            <#return "ABORT: Couldn't convert into string non hash, non method, non boolean, non enumerable object">
         <#recover>
+            <#return "ABORT: Undefined error converting ftl object to JS">
         </#attempt>
-
-        <#return "ABORT: Couldn't convert into string non hash, non method, non boolean, non enumerable object">
 
 </#function>
 <#function are_same_path path searchedPath>

--- a/src/bin/build-keycloak-theme/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
+++ b/src/bin/build-keycloak-theme/generateFtl/ftl_object_to_js_code_declaring_an_object.ftl
@@ -96,215 +96,215 @@ ${ftl_object_to_js_code_declaring_an_object(.data_model, [])?no_esc};
 
 })()
 <#function ftl_object_to_js_code_declaring_an_object object path>
+
+        <#local isHash = "">
         <#attempt>
-            <#local isHash = "">
+            <#local isHash = object?is_hash || object?is_hash_ex>
+        <#recover>
+            <#return "ABORT: Can't evaluate if " + path?join(".") + " is hash">
+        </#attempt>
+
+        <#if isHash>
+
+            <#if path?size gt 10>
+                <#return "ABORT: Too many recursive calls">
+            </#if>
+
+            <#local keys = "">
+
             <#attempt>
-                <#local isHash = object?is_hash || object?is_hash_ex>
+                <#local keys = object?keys>
             <#recover>
-                <#return "ABORT: Can't evaluate if " + path?join(".") + " is hash">
+                <#return "ABORT: We can't list keys on this object">
             </#attempt>
 
-            <#if isHash>
 
-                <#if path?size gt 10>
-                    <#return "ABORT: Too many recursive calls">
+            <#local out_seq = []>
+
+            <#list keys as key>
+
+                <#if ["class","declaredConstructors","superclass","declaringClass" ]?seq_contains(key) >
+                    <#continue>
                 </#if>
 
-                <#local keys = "">
+                <#if
+                    (
+                        ["loginUpdatePasswordUrl", "loginUpdateProfileUrl", "loginUsernameReminderUrl", "loginUpdateTotpUrl"]?seq_contains(key) &&
+                        are_same_path(path, ["url"])
+                    ) || (
+                        key == "updateProfileCtx" &&
+                        are_same_path(path, [])
+                    ) || (
+                        <#-- https://github.com/InseeFrLab/keycloakify/pull/65#issuecomment-991896344 (reports with saml-post-form.ftl) -->
+                        <#-- https://github.com/InseeFrLab/keycloakify/issues/91#issue-1212319466 (reports with error.ftl and Kc18) -->
+                        <#-- https://github.com/InseeFrLab/keycloakify/issues/109#issuecomment-1134610163 -->
+                        key == "loginAction" &&
+                        are_same_path(path, ["url"]) &&
+                        ["saml-post-form.ftl", "error.ftl", "info.ftl"]?seq_contains(pageId) &&
+                        !(auth?has_content && auth.showTryAnotherWayLink())
+                    ) || (
+                        ["contextData", "idpConfig", "idp", "authenticationSession"]?seq_contains(key) &&
+                        are_same_path(path, ["brokerContext"]) &&
+                        ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
+                    ) || (
+                        key == "identityProviderBrokerCtx" &&
+                        are_same_path(path, []) &&
+                        ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
+                    ) ||  (
+                        ["masterAdminClient", "delegateForUpdate", "defaultRole"]?seq_contains(key) &&
+                        are_same_path(path, ["realm"])
+                    )
+                >
+                    <#local out_seq += ["/*If you need '" + key + "' on " + pageId + ", please submit an issue to the Keycloakify repo*/"]>
+                    <#continue>
+                </#if>
 
-                <#attempt>
-                    <#local keys = object?keys>
-                <#recover>
-                    <#return "ABORT: We can't list keys on this object">
-                </#attempt>
-
-
-                <#local out_seq = []>
-
-                <#list keys as key>
-
-                    <#if ["class","declaredConstructors","superclass","declaringClass" ]?seq_contains(key) >
-                        <#continue>
-                    </#if>
-
-                    <#if
-                        (
-                            ["loginUpdatePasswordUrl", "loginUpdateProfileUrl", "loginUsernameReminderUrl", "loginUpdateTotpUrl"]?seq_contains(key) &&
-                            are_same_path(path, ["url"])
-                        ) || (
-                            key == "updateProfileCtx" &&
-                            are_same_path(path, [])
-                        ) || (
-                            <#-- https://github.com/InseeFrLab/keycloakify/pull/65#issuecomment-991896344 (reports with saml-post-form.ftl) -->
-                            <#-- https://github.com/InseeFrLab/keycloakify/issues/91#issue-1212319466 (reports with error.ftl and Kc18) -->
-                            <#-- https://github.com/InseeFrLab/keycloakify/issues/109#issuecomment-1134610163 -->
-                            key == "loginAction" &&
-                            are_same_path(path, ["url"]) &&
-                            ["saml-post-form.ftl", "error.ftl", "info.ftl"]?seq_contains(pageId) &&
-                            !(auth?has_content && auth.showTryAnotherWayLink())
-                        ) || (
-                            ["contextData", "idpConfig", "idp", "authenticationSession"]?seq_contains(key) &&
-                            are_same_path(path, ["brokerContext"]) &&
-                            ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
-                        ) || (
-                            key == "identityProviderBrokerCtx" &&
-                            are_same_path(path, []) &&
-                            ["login-idp-link-confirm.ftl", "login-idp-link-email.ftl" ]?seq_contains(pageId)
-                        ) ||  (
-                            ["masterAdminClient", "delegateForUpdate", "defaultRole"]?seq_contains(key) &&
-                            are_same_path(path, ["realm"])
-                        )
-                    >
-                        <#local out_seq += ["/*If you need '" + key + "' on " + pageId + ", please submit an issue to the Keycloakify repo*/"]>
-                        <#continue>
-                    </#if>
-
-                    <#if key == "attemptedUsername" && are_same_path(path, ["auth"])>
-
-                        <#attempt>
-                            <#-- https://github.com/keycloak/keycloak/blob/3a2bf0c04bcde185e497aaa32d0bb7ab7520cf4a/themes/src/main/resources/theme/base/login/template.ftl#L63 -->
-                            <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
-                                <#continue>
-                            </#if>
-                        <#recover>
-                        </#attempt>
-
-                    </#if>
+                <#if key == "attemptedUsername" && are_same_path(path, ["auth"])>
 
                     <#attempt>
-                        <#if !object[key]??>
+                        <#-- https://github.com/keycloak/keycloak/blob/3a2bf0c04bcde185e497aaa32d0bb7ab7520cf4a/themes/src/main/resources/theme/base/login/template.ftl#L63 -->
+                        <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
                             <#continue>
                         </#if>
                     <#recover>
-                        <#local out_seq += ["/*Couldn't test if '" + key + "' is available on this object*/"]>
-                        <#continue>
                     </#attempt>
 
-                    <#local propertyValue = "">
+                </#if>
 
-                    <#attempt>
-                        <#local propertyValue = object[key]>
-                    <#recover>
-                        <#local out_seq += ["/*Couldn't dereference '" + key + "' on this object*/"]>
-                        <#continue>
-                    </#attempt>
-
-                    <#local rec_out = ftl_object_to_js_code_declaring_an_object(propertyValue, path + [ key ])>
-
-                    <#if rec_out?starts_with("ABORT:")>
-
-                        <#local errorMessage = rec_out?remove_beginning("ABORT:")>
-
-                        <#if errorMessage != " It's a method" >
-                            <#local out_seq += ["/*" + key + ": " + errorMessage + "*/"]>
-                        </#if>
-
+                <#attempt>
+                    <#if !object[key]??>
                         <#continue>
                     </#if>
+                <#recover>
+                    <#local out_seq += ["/*Couldn't test if '" + key + "' is available on this object*/"]>
+                    <#continue>
+                </#attempt>
 
-                    <#local out_seq +=  ['"' + key + '": ' + rec_out + ","]>
+                <#local propertyValue = "">
 
-                </#list>
+                <#attempt>
+                    <#local propertyValue = object[key]>
+                <#recover>
+                    <#local out_seq += ["/*Couldn't dereference '" + key + "' on this object*/"]>
+                    <#continue>
+                </#attempt>
 
-                <#return (["{"] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "}"])?join("\n")>
+                <#local rec_out = ftl_object_to_js_code_declaring_an_object(propertyValue, path + [ key ])>
 
-            </#if>
+                <#if rec_out?starts_with("ABORT:")>
 
-            <#local isMethod = "">
-            <#attempt>
-                <#local isMethod = object?is_method>
-            <#recover>
-                <#return "ABORT: Can't test if it'sa method.">
-            </#attempt>
+                    <#local errorMessage = rec_out?remove_beginning("ABORT:")>
 
-            <#if isMethod>
-
-                <#if are_same_path(path, ["auth", "showUsername"])>
-                    <#attempt>
-                        <#return auth.showUsername()?c>
-                    <#recover>
-                        <#return "ABORT: Couldn't evaluate auth.showUsername()">
-                    </#attempt>
-                </#if>
-
-                <#if are_same_path(path, ["auth", "showResetCredentials"])>
-                    <#attempt>
-                        <#return auth.showResetCredentials()?c>
-                    <#recover>
-                        <#return "ABORT: Couldn't evaluate auth.showResetCredentials()">
-                    </#attempt>
-                </#if>
-
-                <#if are_same_path(path, ["auth", "showTryAnotherWayLink"])>
-                    <#attempt>
-                        <#return auth.showTryAnotherWayLink()?c>
-                    <#recover>
-                        <#return "ABORT: Couldn't evaluate auth.showTryAnotherWayLink()">
-                    </#attempt>
-                </#if>
-
-                <#return "ABORT: It's a method">
-            </#if>
-
-            <#local isBoolean = "">
-            <#attempt>
-                <#local isBoolean = object?is_boolean>
-            <#recover>
-                <#return "ABORT: Can't test if it's a boolean">
-            </#attempt>
-
-            <#if isBoolean>
-                <#return object?c>
-            </#if>
-
-            <#local isEnumerable = "">
-            <#attempt>
-                <#local isEnumerable = object?is_enumerable>
-            <#recover>
-                <#return "ABORT: Can't test if it's an enumerable">
-            </#attempt>
-
-
-            <#if isEnumerable>
-
-                <#local out_seq = []>
-
-                <#local i = 0>
-
-                <#list object as array_item>
-
-                    <#local rec_out = ftl_object_to_js_code_declaring_an_object(array_item, path + [ i ])>
-
-                    <#local i = i + 1>
-
-                    <#if rec_out?starts_with("ABORT:")>
-
-                        <#local errorMessage = rec_out?remove_beginning("ABORT:")>
-
-                        <#if errorMessage != " It's a method" >
-                            <#local out_seq += ["/*" + i?string + ": " + errorMessage + "*/"]>
-                        </#if>
-
-                        <#continue>
+                    <#if errorMessage != " It's a method" >
+                        <#local out_seq += ["/*" + key + ": " + errorMessage + "*/"]>
                     </#if>
 
-                    <#local out_seq += [rec_out + ","]>
+                    <#continue>
+                </#if>
 
-                </#list>
+                <#local out_seq +=  ['"' + key + '": ' + rec_out + ","]>
 
-                <#return (["["] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "]"])?join("\n")>
+            </#list>
 
-            </#if>
+            <#return (["{"] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "}"])?join("\n")>
 
-            <#attempt>
-                <#return '"' + object?js_string + '"'>;
-            <#recover>
-            </#attempt>
+        </#if>
 
-            <#return "ABORT: Couldn't convert into string non hash, non method, non boolean, non enumerable object">
+        <#local isMethod = "">
+        <#attempt>
+            <#local isMethod = object?is_method>
         <#recover>
-            <#return "ABORT: Undefined error converting ftl object to JS">
+            <#return "ABORT: Can't test if it'sa method.">
         </#attempt>
+
+        <#if isMethod>
+
+            <#if are_same_path(path, ["auth", "showUsername"])>
+                <#attempt>
+                    <#return auth.showUsername()?c>
+                <#recover>
+                    <#return "ABORT: Couldn't evaluate auth.showUsername()">
+                </#attempt>
+            </#if>
+
+            <#if are_same_path(path, ["auth", "showResetCredentials"])>
+                <#attempt>
+                    <#return auth.showResetCredentials()?c>
+                <#recover>
+                    <#return "ABORT: Couldn't evaluate auth.showResetCredentials()">
+                </#attempt>
+            </#if>
+
+            <#if are_same_path(path, ["auth", "showTryAnotherWayLink"])>
+                <#attempt>
+                    <#return auth.showTryAnotherWayLink()?c>
+                <#recover>
+                    <#return "ABORT: Couldn't evaluate auth.showTryAnotherWayLink()">
+                </#attempt>
+            </#if>
+
+            <#return "ABORT: It's a method">
+        </#if>
+
+        <#local isBoolean = "">
+        <#attempt>
+            <#local isBoolean = object?is_boolean>
+        <#recover>
+            <#return "ABORT: Can't test if it's a boolean">
+        </#attempt>
+
+        <#if isBoolean>
+            <#return object?c>
+        </#if>
+
+        <#local isEnumerable = "">
+        <#attempt>
+            <#local isEnumerable = object?is_enumerable>
+        <#recover>
+            <#return "ABORT: Can't test if it's an enumerable">
+        </#attempt>
+
+
+        <#if isEnumerable>
+
+            <#local out_seq = []>
+
+            <#local i = 0>
+
+            <#list object as array_item>
+                <#attempt>
+                <#local rec_out = ftl_object_to_js_code_declaring_an_object(array_item, path + [ i ])>
+                <#recover>
+                    <#return "ABORT: Unable to convert recursive array item in enumerable">
+                </#attempt>
+
+                <#local i = i + 1>
+
+                <#if rec_out?starts_with("ABORT:")>
+
+                    <#local errorMessage = rec_out?remove_beginning("ABORT:")>
+
+                    <#if errorMessage != " It's a method" >
+                        <#local out_seq += ["/*" + i?string + ": " + errorMessage + "*/"]>
+                    </#if>
+
+                    <#continue>
+                </#if>
+
+                <#local out_seq += [rec_out + ","]>
+
+            </#list>
+
+            <#return (["["] + out_seq?map(str -> ""?right_pad(4 * (path?size + 1)) + str) + [ ""?right_pad(4 * path?size) + "]"])?join("\n")>
+
+        </#if>
+
+        <#attempt>
+            <#return '"' + object?js_string + '"'>;
+        <#recover>
+        </#attempt>
+
+        <#return "ABORT: Couldn't convert into string non hash, non method, non boolean, non enumerable object">
 
 </#function>
 <#function are_same_path path searchedPath>


### PR DESCRIPTION
Hi,

I have notice 500 errors on some of my customs `.ftl` in some scenarios (`update-user-profile.ftl` , `idp-review-user-profile.ftl`) probably due to the `data_model` not being converted in a successfully way.
Adding `<#attempt>` and `<#recover>` inside the whole function prevent at least the page from crashing and going 500.

Thanks for merging!