### PR TITLE
feat: add silent flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "devDependencies": {
         "@emotion/react": "^11.4.1",
         "@types/memoizee": "^0.4.7",
+        "@types/minimist": "^1.2.2",
         "@types/node": "^17.0.25",
         "@types/react": "18.0.9",
         "copyfiles": "^2.4.1",
@@ -78,6 +79,7 @@
         "evt": "^2.4.0",
         "memoizee": "^0.4.15",
         "minimal-polyfills": "^2.2.2",
+        "minimist": "^1.2.6",
         "path-browserify": "^1.0.1",
         "powerhooks": "^0.20.15",
         "react-markdown": "^5.0.3",

--- a/src/bin/create-keycloak-email-directory.ts
+++ b/src/bin/create-keycloak-email-directory.ts
@@ -26,7 +26,7 @@ if (require.main === module) {
         downloadBuiltinKeycloakTheme({
             keycloakVersion,
             "destDirPath": builtinKeycloakThemeTmpDirPath,
-            "isSilent": isSilent
+            isSilent
         });
 
         transformCodebase({

--- a/src/bin/create-keycloak-email-directory.ts
+++ b/src/bin/create-keycloak-email-directory.ts
@@ -6,11 +6,15 @@ import { join as pathJoin, basename as pathBasename } from "path";
 import { transformCodebase } from "./tools/transformCodebase";
 import { promptKeycloakVersion } from "./promptKeycloakVersion";
 import * as fs from "fs";
+import { getCliOptions } from "./tools/cliOptions";
+import { getLogger } from "./tools/logger";
 
 if (require.main === module) {
     (async () => {
+        const { isSilent } = getCliOptions(process.argv.slice(2));
+        const logger = getLogger({ isSilent });
         if (fs.existsSync(keycloakThemeEmailDirPath)) {
-            console.log(`There is already a ./${pathBasename(keycloakThemeEmailDirPath)} directory in your project. Aborting.`);
+            logger.warn(`There is already a ./${pathBasename(keycloakThemeEmailDirPath)} directory in your project. Aborting.`);
 
             process.exit(-1);
         }
@@ -21,7 +25,8 @@ if (require.main === module) {
 
         downloadBuiltinKeycloakTheme({
             keycloakVersion,
-            "destDirPath": builtinKeycloakThemeTmpDirPath
+            "destDirPath": builtinKeycloakThemeTmpDirPath,
+            "isSilent": isSilent
         });
 
         transformCodebase({
@@ -29,7 +34,7 @@ if (require.main === module) {
             "destDirPath": keycloakThemeEmailDirPath
         });
 
-        console.log(`./${pathBasename(keycloakThemeEmailDirPath)} ready to be customized`);
+        logger.log(`./${pathBasename(keycloakThemeEmailDirPath)} ready to be customized`);
 
         fs.rmSync(builtinKeycloakThemeTmpDirPath, { "recursive": true, "force": true });
     })();

--- a/src/bin/download-builtin-keycloak-theme.ts
+++ b/src/bin/download-builtin-keycloak-theme.ts
@@ -4,31 +4,37 @@ import { keycloakThemeBuildingDirPath } from "./keycloakify";
 import { join as pathJoin } from "path";
 import { downloadAndUnzip } from "./tools/downloadAndUnzip";
 import { promptKeycloakVersion } from "./promptKeycloakVersion";
+import { getCliOptions } from "./tools/cliOptions";
+import { getLogger } from "./tools/logger";
 
-export function downloadBuiltinKeycloakTheme(params: { keycloakVersion: string; destDirPath: string }) {
-    const { keycloakVersion, destDirPath } = params;
+export function downloadBuiltinKeycloakTheme(params: { keycloakVersion: string; destDirPath: string; isSilent: boolean }) {
+    const { keycloakVersion, destDirPath, isSilent } = params;
 
     for (const ext of ["", "-community"]) {
         downloadAndUnzip({
             "destDirPath": destDirPath,
             "url": `https://github.com/keycloak/keycloak/archive/refs/tags/${keycloakVersion}.zip`,
             "pathOfDirToExtractInArchive": `keycloak-${keycloakVersion}/themes/src/main/resources${ext}/theme`,
-            "cacheDirPath": pathJoin(keycloakThemeBuildingDirPath, ".cache")
+            "cacheDirPath": pathJoin(keycloakThemeBuildingDirPath, ".cache"),
+            "isSilent": isSilent
         });
     }
 }
 
 if (require.main === module) {
     (async () => {
+        const { isSilent } = getCliOptions(process.argv.slice(2));
+        const logger = getLogger({ isSilent });
         const { keycloakVersion } = await promptKeycloakVersion();
 
         const destDirPath = pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "theme");
 
-        console.log(`Downloading builtins theme of Keycloak ${keycloakVersion} here ${destDirPath}`);
+        logger.log(`Downloading builtins theme of Keycloak ${keycloakVersion} here ${destDirPath}`);
 
         downloadBuiltinKeycloakTheme({
             keycloakVersion,
-            destDirPath
+            destDirPath,
+            isSilent
         });
     })();
 }

--- a/src/bin/download-builtin-keycloak-theme.ts
+++ b/src/bin/download-builtin-keycloak-theme.ts
@@ -16,7 +16,7 @@ export function downloadBuiltinKeycloakTheme(params: { keycloakVersion: string; 
             "url": `https://github.com/keycloak/keycloak/archive/refs/tags/${keycloakVersion}.zip`,
             "pathOfDirToExtractInArchive": `keycloak-${keycloakVersion}/themes/src/main/resources${ext}/theme`,
             "cacheDirPath": pathJoin(keycloakThemeBuildingDirPath, ".cache"),
-            "isSilent": isSilent
+            isSilent
         });
     }
 }

--- a/src/bin/generate-i18n-messages.ts
+++ b/src/bin/generate-i18n-messages.ts
@@ -5,6 +5,8 @@ import { crawl } from "./tools/crawl";
 import { downloadBuiltinKeycloakTheme } from "./download-builtin-keycloak-theme";
 import { getProjectRoot } from "./tools/getProjectRoot";
 import { rm_rf, rm_r } from "./tools/rm";
+import { getCliOptions } from "./tools/cliOptions";
+import { getLogger } from "./tools/logger";
 
 //NOTE: To run without argument when we want to generate src/i18n/generated_kcMessages files,
 // update the version array for generating for newer version.
@@ -12,8 +14,11 @@ import { rm_rf, rm_r } from "./tools/rm";
 //@ts-ignore
 const propertiesParser = require("properties-parser");
 
+const { isSilent } = getCliOptions(process.argv.slice(2));
+const logger = getLogger({ isSilent });
+
 for (const keycloakVersion of ["11.0.3", "15.0.2", "18.0.1"]) {
-    console.log({ keycloakVersion });
+    logger.log(JSON.stringify({ keycloakVersion }));
 
     const tmpDirPath = pathJoin(getProjectRoot(), "tmp_xImOef9dOd44");
 
@@ -21,7 +26,8 @@ for (const keycloakVersion of ["11.0.3", "15.0.2", "18.0.1"]) {
 
     downloadBuiltinKeycloakTheme({
         keycloakVersion,
-        "destDirPath": tmpDirPath
+        "destDirPath": tmpDirPath,
+        "isSilent": isSilent
     });
 
     type Dictionary = { [idiomId: string]: string };
@@ -75,7 +81,7 @@ for (const keycloakVersion of ["11.0.3", "15.0.2", "18.0.1"]) {
                 )
             );
 
-            console.log(`${filePath} wrote`);
+            logger.log(`${filePath} wrote`);
         });
     });
 }

--- a/src/bin/generate-i18n-messages.ts
+++ b/src/bin/generate-i18n-messages.ts
@@ -27,7 +27,7 @@ for (const keycloakVersion of ["11.0.3", "15.0.2", "18.0.1"]) {
     downloadBuiltinKeycloakTheme({
         keycloakVersion,
         "destDirPath": tmpDirPath,
-        "isSilent": isSilent
+        isSilent
     });
 
     type Dictionary = { [idiomId: string]: string };

--- a/src/bin/keycloakify/BuildOptions.ts
+++ b/src/bin/keycloakify/BuildOptions.ts
@@ -35,6 +35,7 @@ export type BuildOptions = BuildOptions.Standalone | BuildOptions.ExternalAssets
 
 export namespace BuildOptions {
     export type Common = {
+        isSilent: boolean;
         version: string;
         themeName: string;
         extraPages?: string[];
@@ -71,8 +72,9 @@ export function readBuildOptions(params: {
     packageJson: string;
     CNAME: string | undefined;
     isExternalAssetsCliParamProvided: boolean;
+    isSilent: boolean;
 }): BuildOptions {
-    const { packageJson, CNAME, isExternalAssetsCliParamProvided } = params;
+    const { packageJson, CNAME, isExternalAssetsCliParamProvided, isSilent } = params;
 
     const parsedPackageJson = zParsedPackageJson.parse(JSON.parse(packageJson));
 
@@ -130,7 +132,8 @@ export function readBuildOptions(params: {
             })(),
             "version": version,
             extraPages,
-            extraThemeProperties
+            extraThemeProperties,
+            isSilent
         };
     })();
 

--- a/src/bin/keycloakify/generateKeycloakThemeResources.ts
+++ b/src/bin/keycloakify/generateKeycloakThemeResources.ts
@@ -11,6 +11,7 @@ import { isInside } from "../tools/isInside";
 import type { BuildOptions } from "./BuildOptions";
 import { assert } from "tsafe/assert";
 import { Reflect } from "tsafe/Reflect";
+import { getLogger } from "../tools/logger";
 
 export type BuildOptionsLike = BuildOptionsLike.Standalone | BuildOptionsLike.ExternalAssets;
 
@@ -19,6 +20,7 @@ export namespace BuildOptionsLike {
         themeName: string;
         extraPages?: string[];
         extraThemeProperties?: string[];
+        isSilent: boolean;
     };
 
     export type Standalone = Common & {
@@ -60,6 +62,7 @@ export function generateKeycloakThemeResources(params: {
 }): { doBundlesEmailTemplate: boolean } {
     const { reactAppBuildDirPath, keycloakThemeBuildingDirPath, keycloakThemeEmailDirPath, keycloakVersion, buildOptions } = params;
 
+    const logger = getLogger({ isSilent: buildOptions.isSilent });
     const themeDirPath = pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "theme", buildOptions.themeName, "login");
 
     let allCssGlobalsToDefine: Record<string, string> = {};
@@ -117,7 +120,7 @@ export function generateKeycloakThemeResources(params: {
 
     email: {
         if (!fs.existsSync(keycloakThemeEmailDirPath)) {
-            console.log(
+            logger.log(
                 [
                     `Not bundling email template because ${pathBasename(keycloakThemeEmailDirPath)} does not exist`,
                     `To start customizing the email template, run: 👉 npx create-keycloak-email-directory 👈`
@@ -154,7 +157,8 @@ export function generateKeycloakThemeResources(params: {
 
         downloadBuiltinKeycloakTheme({
             keycloakVersion,
-            "destDirPath": tmpDirPath
+            "destDirPath": tmpDirPath,
+            isSilent: buildOptions.isSilent
         });
 
         const themeResourcesDirPath = pathJoin(themeDirPath, "resources");

--- a/src/bin/keycloakify/keycloakify.ts
+++ b/src/bin/keycloakify/keycloakify.ts
@@ -5,6 +5,8 @@ import * as child_process from "child_process";
 import { generateStartKeycloakTestingContainer } from "./generateStartKeycloakTestingContainer";
 import * as fs from "fs";
 import { readBuildOptions } from "./BuildOptions";
+import { getLogger } from "../tools/logger";
+import { getCliOptions } from "../tools/cliOptions";
 
 const reactProjectDirPath = process.cwd();
 
@@ -12,7 +14,9 @@ export const keycloakThemeBuildingDirPath = pathJoin(reactProjectDirPath, "build
 export const keycloakThemeEmailDirPath = pathJoin(keycloakThemeBuildingDirPath, "..", "keycloak_email");
 
 export function main() {
-    console.log("🔏 Building the keycloak theme...⌚");
+    const { isSilent, hasExternalAssets } = getCliOptions(process.argv.slice(2));
+    const logger = getLogger({ isSilent });
+    logger.log("🔏 Building the keycloak theme...⌚");
 
     const buildOptions = readBuildOptions({
         "packageJson": fs.readFileSync(pathJoin(reactProjectDirPath, "package.json")).toString("utf8"),
@@ -25,7 +29,8 @@ export function main() {
 
             return fs.readFileSync(cnameFilePath).toString("utf8");
         })(),
-        "isExternalAssetsCliParamProvided": process.argv[2]?.toLowerCase() === "--external-assets"
+        "isExternalAssetsCliParamProvided": hasExternalAssets,
+        "isSilent": isSilent
     });
 
     const { doBundlesEmailTemplate } = generateKeycloakThemeResources({
@@ -59,7 +64,7 @@ export function main() {
         buildOptions
     });
 
-    console.log(
+    logger.log(
         [
             "",
             `✅ Your keycloak theme has been generated and bundled into ./${pathRelative(reactProjectDirPath, jarFilePath)} 🚀`,

--- a/src/bin/tools/cliOptions.ts
+++ b/src/bin/tools/cliOptions.ts
@@ -1,0 +1,15 @@
+import parseArgv from "minimist";
+
+export type CliOptions = {
+    isSilent: boolean;
+    hasExternalAssets: boolean;
+};
+
+export const getCliOptions = (processArgv: string[]): CliOptions => {
+    const argv = parseArgv(processArgv);
+
+    return {
+        isSilent: typeof argv["silent"] === "boolean" ? argv["silent"] : false,
+        hasExternalAssets: argv["external-assets"] !== undefined
+    };
+};

--- a/src/bin/tools/cliOptions.ts
+++ b/src/bin/tools/cliOptions.ts
@@ -10,6 +10,6 @@ export const getCliOptions = (processArgv: string[]): CliOptions => {
 
     return {
         isSilent: typeof argv["silent"] === "boolean" ? argv["silent"] : false,
-        hasExternalAssets: argv["external-assets"] !== undefined
+        hasExternalAssets: typeof argv["external-assets"] === "boolean" ? argv["external-assets"] : false
     };
 };

--- a/src/bin/tools/downloadAndUnzip.ts
+++ b/src/bin/tools/downloadAndUnzip.ts
@@ -6,7 +6,13 @@ import { rm, rm_rf } from "./rm";
 import * as crypto from "crypto";
 
 /** assert url ends with .zip */
-export function downloadAndUnzip(params: { url: string; destDirPath: string; pathOfDirToExtractInArchive?: string; cacheDirPath: string }) {
+export function downloadAndUnzip(params: {
+    isSilent: boolean;
+    url: string;
+    destDirPath: string;
+    pathOfDirToExtractInArchive?: string;
+    cacheDirPath: string;
+}) {
     const { url, destDirPath, pathOfDirToExtractInArchive, cacheDirPath } = params;
 
     const extractDirPath = pathJoin(
@@ -54,7 +60,7 @@ export function downloadAndUnzip(params: { url: string; destDirPath: string; pat
 
         const zipFileBasename = pathBasename(url);
 
-        execSync(`curl -L ${url} -o ${zipFileBasename}`, { "cwd": extractDirPath });
+        execSync(`curl -L ${url} -o ${zipFileBasename} ${params.isSilent ? "-s" : ""}`, { "cwd": extractDirPath });
 
         execSync(`unzip -o ${zipFileBasename}${pathOfDirToExtractInArchive === undefined ? "" : ` "${pathOfDirToExtractInArchive}/**/*"`}`, {
             "cwd": extractDirPath

--- a/src/bin/tools/logger.ts
+++ b/src/bin/tools/logger.ts
@@ -1,0 +1,27 @@
+type LoggerOpts = {
+    force?: boolean;
+};
+
+type Logger = {
+    log: (message: string, opts?: LoggerOpts) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+};
+
+export const getLogger = ({ isSilent }: { isSilent?: boolean } = {}): Logger => {
+    return {
+        log: (message, { force } = {}) => {
+            if (isSilent && !force) {
+                return;
+            }
+
+            console.log(message);
+        },
+        warn: message => {
+            console.warn(message);
+        },
+        error: message => {
+            console.error(message);
+        }
+    };
+};

--- a/src/test/bin/generateKeycloakThemeResources.ts
+++ b/src/test/bin/generateKeycloakThemeResources.ts
@@ -14,6 +14,7 @@ generateKeycloakThemeResources({
         "extraPages": ["my-custom-page.ftl"],
         "extraThemeProperties": ["env=test"],
         "isStandalone": true,
-        "urlPathname": "/keycloakify-demo-app/"
+        "urlPathname": "/keycloakify-demo-app/",
+        "isSilent": false
     }
 });

--- a/src/test/bin/setupSampleReactProject.ts
+++ b/src/test/bin/setupSampleReactProject.ts
@@ -8,6 +8,7 @@ export function setupSampleReactProject() {
     downloadAndUnzip({
         "url": "https://github.com/InseeFrLab/keycloakify/releases/download/v0.0.1/sample_build_dir_and_package_json.zip",
         "destDirPath": sampleReactProjectDirPath,
-        "cacheDirPath": pathJoin(sampleReactProjectDirPath, "build_keycloak", ".cache")
+        "cacheDirPath": pathJoin(sampleReactProjectDirPath, "build_keycloak", ".cache"),
+        "isSilent": false
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,6 +265,11 @@
   resolved "https://registry.yarnpkg.com/@types/memoizee/-/memoizee-0.4.8.tgz#04adc0c266a0f5d72db0556fdda2ba17dad9b519"
   integrity sha512-qDpXKGgwKywnQt/64fH1O0LiPA++QGIYeykEUiZ51HymKVRLnUSGcRuF60IfpPeeXiuRwiR/W4y7S5VzbrgLCA==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node@^17.0.25":
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
@@ -1187,6 +1192,11 @@ minimatch@^3.0.3, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
I have implemented a feature that adds support for the `--silent` flag that suppresses non-critical messages (i.e. warnings and errors are still surfaced)

I have decided to add two abstractions to implement this.

1. `getCliOptions` is a helper which is responsible for parsing different CLI options. Currently, it supports only the silent flag and the external assets flag. When we decide to add new flags, this abstraction might make it easier for us. It also brings a small utility library which takes care of parsing the CLI arguments and all the different edge cases of that.

2. `getLogger` is an abstraction for `console.*` functions that encapsulate some code (currently, only the silencing logic).  This allows us to replace `console.*` with `logger.*` in majority of the places and be done with it. We could potentially extend the logic further in case some other requirements surface up later.

Tell me what you think about it and whether there are any alternatives solution which you have thought about. 

