### PR TITLE
Fix typo in development docs

### DIFF
--- a/developpement.md
+++ b/developpement.md
@@ -8,7 +8,7 @@ description: Test and debug your theme
 
 When building your page you want to see the result of your edit live.
 
-To acheave that with Keycloakify simply eddit:
+To achieve this with Keycloakify simply edit:
 
 ```diff
  import { getKcContext } from "keycloakify";


### PR DESCRIPTION
I noticed this tiny typo when reading through the documentation. 

There also seems to be a typo in the file name `developpement.md`. Should it be `development.md`? I have kept the filename as it is, in case changing would break links. 