### PR TITLE
keycloak test script: use env to launch bash

### DIFF
--- a/src/bin/keycloakify/generateStartKeycloakTestingContainer.ts
+++ b/src/bin/keycloakify/generateStartKeycloakTestingContainer.ts
@@ -34,7 +34,7 @@ export function generateStartKeycloakTestingContainer(params: {
         pathJoin(keycloakThemeBuildingDirPath, generateStartKeycloakTestingContainer.basename),
         Buffer.from(
             [
-                "#!/bin/bash",
+                "#!/usr/bin/env bash",
                 "",
                 `docker rm ${containerName} || true`,
                 "",


### PR DESCRIPTION
This minor change allows users to use the latest version of `bash` on Mac OS.

`/bin/bash` is very old on Mac OS, and many users will have `bash` from MacPorts or Homebrew. This change allows such users to be able to use the newer `bash` installation.