### PR TITLE
Asynchronize transform and download pipeline

### DIFF
--- a/src/bin/download-builtin-keycloak-theme.ts
+++ b/src/bin/download-builtin-keycloak-theme.ts
@@ -10,15 +10,17 @@ import { getLogger } from "./tools/logger";
 export async function downloadBuiltinKeycloakTheme(params: { keycloakVersion: string; destDirPath: string; isSilent: boolean }) {
     const { keycloakVersion, destDirPath, isSilent } = params;
 
-    for (const ext of ["", "-community"]) {
-        await downloadAndUnzip({
-            "destDirPath": destDirPath,
-            "url": `https://github.com/keycloak/keycloak/archive/refs/tags/${keycloakVersion}.zip`,
-            "pathOfDirToExtractInArchive": `keycloak-${keycloakVersion}/themes/src/main/resources${ext}/theme`,
-            "cacheDirPath": pathJoin(keycloakThemeBuildingDirPath, ".cache"),
-            isSilent
-        });
-    }
+    await Promise.all(
+        ["", "-community"].map(ext =>
+            downloadAndUnzip({
+                "destDirPath": destDirPath,
+                "url": `https://github.com/keycloak/keycloak/archive/refs/tags/${keycloakVersion}.zip`,
+                "pathOfDirToExtractInArchive": `keycloak-${keycloakVersion}/themes/src/main/resources${ext}/theme`,
+                "cacheDirPath": pathJoin(keycloakThemeBuildingDirPath, ".cache"),
+                isSilent
+            })
+        )
+    );
 }
 
 if (require.main === module) {

--- a/src/bin/keycloakify/BuildOptions.ts
+++ b/src/bin/keycloakify/BuildOptions.ts
@@ -79,15 +79,15 @@ export namespace BuildOptions {
     }
 }
 
-export function readBuildOptions(params: {
+export async function readBuildOptions(params: {
     packageJson: string;
     CNAME: string | undefined;
     isExternalAssetsCliParamProvided: boolean;
     isSilent: boolean;
-}): BuildOptions {
+}): Promise<BuildOptions> {
     const { packageJson, CNAME, isExternalAssetsCliParamProvided, isSilent } = params;
 
-    const parsedPackageJson = zParsedPackageJson.parse(JSON.parse(packageJson));
+    const parsedPackageJson = await zParsedPackageJson.parseAsync(JSON.parse(packageJson));
 
     const url = (() => {
         const { homepage } = parsedPackageJson;

--- a/src/bin/keycloakify/generateFtl/generateFtl.ts
+++ b/src/bin/keycloakify/generateFtl/generateFtl.ts
@@ -1,8 +1,8 @@
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { replaceImportsFromStaticInJsCode } from "../replacers/replaceImportsFromStaticInJsCode";
 import { generateCssCodeToDefineGlobals } from "../replacers/replaceImportsInCssCode";
 import { replaceImportsInInlineCssCode } from "../replacers/replaceImportsInInlineCssCode";
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import { join as pathJoin } from "path";
 import { objectKeys } from "tsafe/objectKeys";
 import { ftlValuesGlobalName } from "../ftlValuesGlobalName";
@@ -70,7 +70,7 @@ export namespace BuildOptionsLike {
 
 export type PageId = (typeof pageIds)[number];
 
-export function generateFtlFilesCodeFactory(params: {
+export async function generateFtlFilesCodeFactory(params: {
     indexHtmlCode: string;
     //NOTE: Expected to be an empty object if external assets mode is enabled.
     cssGlobalsToDefine: Record<string, string>;
@@ -143,8 +143,7 @@ export function generateFtlFilesCodeFactory(params: {
 
     //FTL is no valid html, we can't insert with cheerio, we put placeholder for injecting later.
     const replaceValueBySearchValue = {
-        '{ "x": "vIdLqMeOed9sdLdIdOxdK0d" }': fs
-            .readFileSync(pathJoin(__dirname, "ftl_object_to_js_code_declaring_an_object.ftl"))
+        '{ "x": "vIdLqMeOed9sdLdIdOxdK0d" }': (await fs.readFile(pathJoin(__dirname, "ftl_object_to_js_code_declaring_an_object.ftl")))
             .toString("utf8")
             .match(/^<script>const _=((?:.|\n)+)<\/script>[\n]?$/)![1],
         "<!-- xIdLqMeOedErIdLsPdNdI9dSlxI -->": [

--- a/src/bin/keycloakify/generateJavaStackFiles.ts
+++ b/src/bin/keycloakify/generateJavaStackFiles.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import { join as pathJoin, dirname as pathDirname } from "path";
 import { assert } from "tsafe/assert";
 import { Reflect } from "tsafe/Reflect";
@@ -17,13 +17,13 @@ export type BuildOptionsLike = {
     assert<typeof buildOptions extends BuildOptionsLike ? true : false>();
 }
 
-export function generateJavaStackFiles(params: {
+export async function generateJavaStackFiles(params: {
     keycloakThemeBuildingDirPath: string;
     doBundlesEmailTemplate: boolean;
     buildOptions: BuildOptionsLike;
-}): {
+}): Promise<{
     jarFilePath: string;
-} {
+}> {
     const {
         buildOptions: { groupId, themeName, version, artifactId },
         keycloakThemeBuildingDirPath,
@@ -51,17 +51,17 @@ export function generateJavaStackFiles(params: {
             return { pomFileCode };
         })();
 
-        fs.writeFileSync(pathJoin(keycloakThemeBuildingDirPath, "pom.xml"), Buffer.from(pomFileCode, "utf8"));
+        await fs.writeFile(pathJoin(keycloakThemeBuildingDirPath, "pom.xml"), Buffer.from(pomFileCode, "utf8"));
     }
 
     {
         const themeManifestFilePath = pathJoin(keycloakThemeBuildingDirPath, "src", "main", "resources", "META-INF", "keycloak-themes.json");
 
         try {
-            fs.mkdirSync(pathDirname(themeManifestFilePath));
+            await fs.mkdir(pathDirname(themeManifestFilePath));
         } catch {}
 
-        fs.writeFileSync(
+        await fs.writeFile(
             themeManifestFilePath,
             Buffer.from(
                 JSON.stringify(

--- a/src/bin/tools/crawl.ts
+++ b/src/bin/tools/crawl.ts
@@ -1,14 +1,14 @@
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import * as path from "path";
 
 /** List all files in a given directory return paths relative to the dir_path */
 export const crawl = (() => {
-    const crawlRec = (dir_path: string, paths: string[]) => {
-        for (const file_name of fs.readdirSync(dir_path)) {
+    const crawlRec = async (dir_path: string, paths: string[]) => {
+        for (const file_name of await fs.readdir(dir_path)) {
             const file_path = path.join(dir_path, file_name);
 
-            if (fs.lstatSync(file_path).isDirectory()) {
-                crawlRec(file_path, paths);
+            if ((await fs.lstat(file_path)).isDirectory()) {
+                await crawlRec(file_path, paths);
 
                 continue;
             }
@@ -17,10 +17,10 @@ export const crawl = (() => {
         }
     };
 
-    return function crawl(dir_path: string): string[] {
+    return async function crawl(dir_path: string): Promise<string[]> {
         const paths: string[] = [];
 
-        crawlRec(dir_path, paths);
+        await crawlRec(dir_path, paths);
 
         return paths.map(file_path => path.relative(dir_path, file_path));
     };


### PR DESCRIPTION
Asynchronize transform and download pipeline and (nearly) every system call to increase build performance. I also fixed download caching by checking the path, at least on my machine download caching did not work as expected. I managed to get build time down from ~35 seconds to ~13 seconds if downloads are cached on my machine.