### PR TITLE
feat(login context): improve login typings

### DIFF
--- a/src/login/kcContext/KcContext.ts
+++ b/src/login/kcContext/KcContext.ts
@@ -101,7 +101,8 @@ export declare namespace KcContext {
         registrationDisabled: boolean;
         login: {
             username?: string;
-            rememberMe?: boolean;
+            rememberMe?: string;
+            password?: string;
         };
         usernameEditDisabled: boolean;
         social: {
@@ -219,7 +220,7 @@ export declare namespace KcContext {
         registrationDisabled: boolean;
         login: {
             username?: string;
-            rememberMe?: boolean;
+            rememberMe?: string;
         };
         usernameHidden?: boolean;
         social: {

--- a/src/login/kcContext/kcContextMocks.ts
+++ b/src/login/kcContext/kcContextMocks.ts
@@ -260,9 +260,7 @@ export const kcContextMocks: KcContext[] = [
             "displayInfo": true
         },
         "usernameEditDisabled": false,
-        "login": {
-            "rememberMe": false
-        },
+        "login": {},
         "registrationDisabled": false
     }),
     ...(() => {
@@ -376,9 +374,7 @@ export const kcContextMocks: KcContext[] = [
             "displayInfo": true
         },
         "usernameHidden": false,
-        "login": {
-            "rememberMe": false
-        },
+        "login": {},
         "registrationDisabled": false
     }),
     id<KcContext.LoginPassword>({

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -124,7 +124,7 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                                                     id="rememberMe"
                                                     name="rememberMe"
                                                     type="checkbox"
-                                                    {...(login.rememberMe
+                                                    {...(login.rememberMe === "on"
                                                         ? {
                                                               "checked": true
                                                           }

--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -109,7 +109,7 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                                                     id="rememberMe"
                                                     name="rememberMe"
                                                     type="checkbox"
-                                                    {...(login.rememberMe
+                                                    {...(login.rememberMe === "on"
                                                         ? {
                                                               "checked": true
                                                           }


### PR DESCRIPTION
Keycloak only treats `rememberMe` as true if the value is `"on"`. [ref](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java#L210)

Additionally, it seems that keycloak will also return the attempted password on failed attempts, which could be useful to pre-populate the form on errors:
![image](https://user-images.githubusercontent.com/10997562/226787279-dbfafacc-8c03-4498-97a5-40a4d49e3732.png)
