### PR TITLE
feat: support predefined context and skip postbuild / skip jars

### DIFF
--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -64,16 +64,40 @@ function skip(_context: any, argv: { options: Record<string, unknown> }) {
 }
 
 program
-    .command({
+    .command<{ skipJar: boolean; skipPostBuild: boolean }>({
         name: "build",
         description: "Build the theme (default subcommand)."
     })
+    .option({
+        key: "skipJar",
+        name: (() => {
+            const name = "skip-jar";
+            optionsKeys.push(name);
+            return name;
+        })(),
+        description: "Skip output JAR file generation.",
+        defaultValue: false
+    })
+    .option({
+        key: "skipPostBuild",
+        name: (() => {
+            const name = "skip-post-build";
+            optionsKeys.push(name);
+            return name;
+        })(),
+        description: "Skip post-build steps.",
+        defaultValue: false
+    })
     .task({
         skip,
-        handler: async ({ projectDirPath }) => {
+        handler: async ({ projectDirPath, skipJar, skipPostBuild }) => {
             const { command } = await import("./keycloakify");
 
-            await command({ buildContext: getBuildContext({ projectDirPath }) });
+            await command({
+                buildContext: getBuildContext({ projectDirPath }),
+                skipJar,
+                skipPostBuild
+            });
         }
     });
 
@@ -373,6 +397,19 @@ program
             });
         }
     });
+
+program.command({
+    name: "print-build-context",
+    description: "print a build context for non npx build runners. pass the result to KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT env variable",
+})
+.task({
+    skip,
+    handler: async ({ projectDirPath }) => {
+        const buildContext = getBuildContext({ projectDirPath });
+        console.log(JSON.stringify(buildContext))
+    }
+})
+
 
 // Fallback to build command if no command is provided
 {

--- a/src/bin/shared/buildContext.ts
+++ b/src/bin/shared/buildContext.ts
@@ -12,7 +12,8 @@ import { assert, type Equals, is } from "tsafe/assert";
 import * as child_process from "child_process";
 import {
     VITE_PLUGIN_SUB_SCRIPTS_ENV_NAMES,
-    BUILD_FOR_KEYCLOAK_MAJOR_VERSION_ENV_NAME
+    BUILD_FOR_KEYCLOAK_MAJOR_VERSION_ENV_NAME,
+    KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT
 } from "./constants";
 import type { KeycloakVersionRange } from "./KeycloakVersionRange";
 import { exclude } from "tsafe";
@@ -132,6 +133,12 @@ export type ResolvedViteConfig = {
 export function getBuildContext(params: {
     projectDirPath: string | undefined;
 }): BuildContext {
+
+    if (process.env[KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT]){
+        console.log("Using predefined build context from env variable");
+        return JSON.parse(process.env[KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT]);
+    }
+
     const projectDirPath =
         params.projectDirPath !== undefined
             ? getAbsoluteAndInOsFormatPath({

--- a/src/bin/shared/constants.ts
+++ b/src/bin/shared/constants.ts
@@ -87,3 +87,5 @@ export const KEYCLOAKIFY_LOGGING_VERSION = "1.0.3";
 export const KEYCLOAKIFY_LOGIN_JAR_BASENAME = `keycloakify-logging-${KEYCLOAKIFY_LOGGING_VERSION}.jar`;
 
 export const TEST_APP_URL = "https://my-theme.keycloakify.dev";
+
+export const KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT = "KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT";


### PR DESCRIPTION
Support build in non `npm, npx` build system by introduce several options to run build command to avoid `child_process` execution.

Mostly the subprocesses are used inside build context factory function. This PR introduce a predefined result of the build context factory function.

- Support predefined build context via env var `KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT`
- Add `--skip-post-build` option to skip post build sub process
- Add `--skip-jar` option to skip mvn packing

## Test

I have tested with the script below to make sure external sub process won't be
invoked during the build

```
#!/bin/bash

set -e

export KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT=$(./node_modules/.bin/keycloakify print-build-context)

npx() {
    echo "npx is forbidden"
    exit 1
}
export -f npx

npm() {
    echo "npm is forbidden"
    exit 1
}
export -f npm

mvn() {
    echo "mvn is forbidden"
    exit 1
}
export -f mvn

./node_modules/.bin/vite build
./node_modules/.bin/keycloakify build --skip-jar --skip-post-build
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CLI flags: --skip-jar to skip JAR generation and related checks, and --skip-post-build to skip post-build steps.
  - Introduced print-build-context command to output the project's build context as JSON for external build runners.
  - Added support for KEYCLOAKIFY_PREDEFINED_BUILD_CONTEXT env var to preload a build context without computing it.
  - Improved user-facing logs, clearly indicating when JAR building or post-build steps are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->