### PR TITLE
feat: add option to use default local maven repo

### DIFF
--- a/src/bin/keycloakify/buildJars/buildJar.ts
+++ b/src/bin/keycloakify/buildJars/buildJar.ts
@@ -3,13 +3,13 @@ import type {
     KeycloakAccountV1Version,
     KeycloakThemeAdditionalInfoExtensionVersion
 } from "./extensionVersions";
-import { join as pathJoin, dirname as pathDirname } from "path";
+import { dirname as pathDirname, join as pathJoin } from "path";
 import { transformCodebase } from "../../tools/transformCodebase";
 import type { BuildContext } from "../../shared/buildContext";
 import * as fs from "fs/promises";
 import {
-    generatePom,
-    BuildContextLike as BuildContextLike_generatePom
+    BuildContextLike as BuildContextLike_generatePom,
+    generatePom
 } from "./generatePom";
 import { readFileSync } from "fs";
 import { isInside } from "../../tools/isInside";
@@ -222,7 +222,14 @@ export async function buildJar(params: {
     }
 
     {
-        const mvnBuildCmd = `mvn -B -ntp clean install -Dmaven.repo.local="${pathJoin(keycloakifyBuildCacheDirPath, ".m2")}"`;
+        const useDefaultMavenRepo =
+            process.env.KEYCLOAKIFY_USE_DEFAULT_MAVEN_REPO === "true";
+
+        const mavenLocalRepoArg = useDefaultMavenRepo
+            ? ""
+            : `-Dmaven.repo.local="${pathJoin(buildContext.cacheDirPath, ".m2")}"`;
+
+        const mvnBuildCmd = `mvn -B -ntp clean install ${mavenLocalRepoArg}`.trim();
 
         await new Promise<void>((resolve, reject) =>
             child_process.exec(


### PR DESCRIPTION
when building on our CI we are required to fetch our dependencies from our Google cloud artifactregistry. 

To log onto it so we are using `com.google.cloud.artifactregistry:artifactregistry-maven-wagon`. since the current maven command use option `maven.repo.local` it can't access the dependency jar that is present in the default

```
 [ERROR] Error executing Maven.
 [ERROR] Extension com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.5 or one of its dependencies could not be resolved: Plugin com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.5 or one of its dependencies could not be resolved:
 	Failed to read artifact descriptor for com.google.cloud.artifactregistry:artifactregistry-maven-wagon:jar:2.2.5
 
 [ERROR] Caused by: Plugin com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.5 or one of its dependencies could not be resolved:
 	Failed to read artifact descriptor for com.google.cloud.artifactregistry:artifactregistry-maven-wagon:jar:2.2.5
```

I tried to copy the artifact to the local repo but since there is a clean-up of the repo ran within during the build command execution. I can't find a way to provide it to keycloakify. 

In order to allow user to log onto registry using mvn extensions I have added an options to use the default maven repo instead of a custom one 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build process can optionally use the default Maven repository or a local cache, allowing more flexible dependency resolution via environment configuration.

* **Refactor**
  * Internal build context and configuration handling refined for more robust and maintainable build orchestration.

* **Chores**
  * Minor code organization and import ordering improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->