### PR TITLE
Fix “Back to Application” button showing on login error page when Home URL is not set

### DIFF
--- a/src/login/pages/Error.tsx
+++ b/src/login/pages/Error.tsx
@@ -21,7 +21,7 @@ export default function Error(props: PageProps<Extract<KcContext, { pageId: "err
         >
             <div id="kc-error-message">
                 <p className="instruction" dangerouslySetInnerHTML={{ __html: kcSanitize(message.summary) }} />
-                {!skipLink && client !== undefined && client.baseUrl !== undefined && (
+                {!skipLink && client !== undefined && client.baseUrl && (
                     <p>
                         <a id="backToApplication" href={client.baseUrl}>
                             {msg("backToApplication")}


### PR DESCRIPTION
The client.baseUrl can be an empty string, which causes the "Back to Application" button to display on the login error page with an empty href when home url doesn't provide.

fix by changing:
```ts
!skipLink && client !== undefined && client.baseUrl !== undefined
``` 
to 
```ts
!skipLink && client !== undefined && client.baseUrl
```

issue #944 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for displaying the back-to-application link on error pages, ensuring it only appears when a valid application URL is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->