### PR TITLE
fix: Fix for LoginUsername page for passkeys authentication

### DIFF
--- a/src/login/pages/LoginUsername.tsx
+++ b/src/login/pages/LoginUsername.tsx
@@ -174,9 +174,13 @@ export default function LoginUsername(props: PageProps<Extract<KcContext, { page
                         </>
                     )}
                     <br />
-                    <a id={authButtonId} href="#" className={kcClsx("kcButtonSecondaryClass", "kcButtonBlockClass")}>
-                        {msg("passkey-doAuthenticate")}
-                    </a>
+                    
+                    <input
+                        id={authButtonId}
+                        type="button"
+                        className={kcClsx("kcButtonClass", "kcButtonDefaultClass", "kcButtonBlockClass", "kcButtonLargeClass")}
+                        value={msgStr("passkey-doAuthenticate")}
+                        />
                 </>
             )}
         </Template>


### PR DESCRIPTION
Replace `<a>` tag with `input` tag as used in [Keycloak](https://github.com/keycloak/keycloak/blob/39e1e40be428e9cdd98c98866655641833a62413/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl#L95). Current implementation with `href=#` in `<a>` tag redirects nowhere. The browser (Firefox) also freezes after clicking the `Sign in with Passkey` button.

### Keycloak impl

```
<input id="authenticateWebAuthnButton" 
           type="button" 
           autofocus="autofocus"
           value="${kcSanitize(msg("passkey-doAuthenticate"))}"
           class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
/>

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the passkey authentication control on the login page with enhanced button styling and improved interaction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->