### PR TITLE
Allow adding RequiredActionProviderModel to KcContext

### DIFF
--- a/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
+++ b/src/bin/keycloakify/generateFtl/kcContextDeclarationTemplate.ftl
@@ -187,6 +187,9 @@ function decodeHtmlEntities(htmlStr){
                 <#if stringified?starts_with("org.keycloak.models.OTPPolicy") >
                     <#break>
                 </#if>
+                <#if stringified?starts_with("org.keycloak.models.RequiredActionProviderModel") >
+                    <#break>
+                </#if>
                 <#list ["models", "services", "authentication", "quarkus.runtime", "transaction", "connections", "utils.ClosingStream"] as namespacePortion>
                     <#if stringified?starts_with("org.keycloak." + namespacePortion)>
                         <#return abort>


### PR DESCRIPTION
As discussed on Discord: https://github.com/netzbegruenung/keycloak-mfa-plugins/tree/main/enforce-mfa outputs all MFA options in a list of RequiredActionProviderModel objects. 
This is blocked by default by Keycloakify for security reasons, but an exception to this is possible. 

This object does not contain any sensitive information, as far as I can see: https://www.keycloak.org/docs-api/latest/javadocs/serialized-form.html#org.keycloak.models.RequiredActionProviderModel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to model type handling for better system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->