### PR TITLE
Choco install maven instead of mvn

### DIFF
--- a/src/bin/keycloakify/keycloakify.ts
+++ b/src/bin/keycloakify/keycloakify.ts
@@ -47,7 +47,7 @@ export async function command(params: { buildContext: BuildContext }) {
                     case "darwin":
                         return "brew install mvn";
                     case "win32":
-                        return "choco install mvn";
+                        return "choco install maven";
                     case "linux":
                     default:
                         return "sudo apt-get install mvn";


### PR DESCRIPTION
Small fix when I was trying to run Keycloak locally - choco install maven instead of mvn. See package link: https://community.chocolatey.org/packages/maven

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Maven installation command for Windows environments to ensure the correct package is properly installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->