### PR TITLE
fix(login): align backToApplication link visibility with standard Keycloak theme

### DIFF
--- a/src/login/pages/Error.tsx
+++ b/src/login/pages/Error.tsx
@@ -21,7 +21,7 @@ export default function Error(props: PageProps<Extract<KcContext, { pageId: "err
         >
             <div id="kc-error-message">
                 <p className="instruction" dangerouslySetInnerHTML={{ __html: kcSanitize(message.summary) }} />
-                {!skipLink && client !== undefined && client.baseUrl !== undefined && (
+                {!skipLink && !!client?.baseUrl && (
                     <p>
                         <a id="backToApplication" href={client.baseUrl}>
                             {msg("backToApplication")}


### PR DESCRIPTION
### Description

In the standard Keycloak `error.ftl` template, the "Back to Application" link is strictly rendered only if `client.baseUrl` has content:
`<#if client?? && client.baseUrl?has_content>` see here : [https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/login/error.ftl](https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/login/error.ftl)

Currently, in Keycloakify's `Error.tsx`, the condition only checks if `client.baseUrl !== undefined`. 
If a Keycloak client is configured without a Base URL, the server passes an empty string (`""`). This causes Keycloakify to render a link with an empty href (`href=""`). 

**Impact:** When a user clicks this empty link, the browser resolves the empty href to the document's base URI. In the context of Keycloakify, this unexpectedly redirects the user to the theme's static resource directory (e.g., `/resources/.../login/my-theme/dist/`) instead of the actual application, resulting in bad UX. The standard Keycloak theme correctly hides this link entirely.

### Changes
Updated the conditional rendering in `Error.tsx` to `!!client?.baseUrl`. This ensures the link is completely hidden if `client.baseUrl` is an empty string, perfectly matching the FreeMarker `?has_content` behavior and preventing React from rendering an empty string node in the DOM.

### Steps to reproduce
1. Trigger an error flow in Keycloak with a client that has no `Base URL` configured.
2. In the standard Keycloak theme, the "Back to Application" link is completely hidden.
3. In Keycloakify, an `<a href="">` is rendered. Clicking it navigates the user to the theme's `dist` resource folder. This PR fixes the discrepancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the "back to application" link visibility logic on the error page for more reliable display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->