### PR TITLE
Fix Vite asset import rewriting for template literal strings

### DIFF
--- a/src/bin/keycloakify/replacers/replaceImportsInJsCode/vite.ts
+++ b/src/bin/keycloakify/replacers/replaceImportsInJsCode/vite.ts
@@ -82,41 +82,21 @@ export function replaceImportsInJsCode_vite(params: {
         basenameOfAssetsFiles
             .map(basenameOfAssetsFile => `${staticDir}${basenameOfAssetsFile}`)
             .forEach(relativePathOfAssetFile => {
-                fixedJsCode = replaceJsStringLiteral({
-                    code: fixedJsCode,
-                    literal: relativePathOfAssetFile,
-                    replacement: `(window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
-                });
+                for (const quoteSymbol of ['"', "'", "`"]) {
+                    fixedJsCode = replaceAll(
+                        fixedJsCode,
+                        `${quoteSymbol}${relativePathOfAssetFile}${quoteSymbol}`,
+                        `(window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
+                    );
 
-                fixedJsCode = replaceJsStringLiteral({
-                    code: fixedJsCode,
-                    literal: `${buildContext.urlPathname ?? "/"}${relativePathOfAssetFile}`,
-                    replacement: `(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
-                });
+                    fixedJsCode = replaceAll(
+                        fixedJsCode,
+                        `${quoteSymbol}${buildContext.urlPathname ?? "/"}${relativePathOfAssetFile}${quoteSymbol}`,
+                        `(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
+                    );
+                }
             });
     }
 
     return { fixedJsCode };
-}
-
-function escapeRegExp(str: string) {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function replaceJsStringLiteral(params: {
-    code: string;
-    literal: string;
-    replacement: string;
-}) {
-    const { code, literal, replacement } = params;
-
-    const escapedLiteral = escapeRegExp(literal);
-
-    return code.replace(
-        new RegExp(
-            `(?:"${escapedLiteral}"|'${escapedLiteral}'|\`${escapedLiteral}\`)`,
-            "g"
-        ),
-        replacement
-    );
 }

--- a/src/bin/keycloakify/replacers/replaceImportsInJsCode/vite.ts
+++ b/src/bin/keycloakify/replacers/replaceImportsInJsCode/vite.ts
@@ -1,7 +1,7 @@
-import { WELL_KNOWN_DIRECTORY_BASE_NAME } from "../../../shared/constants";
+import * as nodePath from "path";
 import { assert } from "tsafe/assert";
 import type { BuildContext } from "../../../shared/buildContext";
-import * as nodePath from "path";
+import { WELL_KNOWN_DIRECTORY_BASE_NAME } from "../../../shared/constants";
 import { replaceAll } from "../../../tools/String.prototype.replaceAll";
 
 export type BuildContextLike = {
@@ -82,19 +82,41 @@ export function replaceImportsInJsCode_vite(params: {
         basenameOfAssetsFiles
             .map(basenameOfAssetsFile => `${staticDir}${basenameOfAssetsFile}`)
             .forEach(relativePathOfAssetFile => {
-                fixedJsCode = replaceAll(
-                    fixedJsCode,
-                    `"${relativePathOfAssetFile}"`,
-                    `(window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
-                );
+                fixedJsCode = replaceJsStringLiteral({
+                    code: fixedJsCode,
+                    literal: relativePathOfAssetFile,
+                    replacement: `(window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
+                });
 
-                fixedJsCode = replaceAll(
-                    fixedJsCode,
-                    `"${buildContext.urlPathname ?? "/"}${relativePathOfAssetFile}"`,
-                    `(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
-                );
+                fixedJsCode = replaceJsStringLiteral({
+                    code: fixedJsCode,
+                    literal: `${buildContext.urlPathname ?? "/"}${relativePathOfAssetFile}`,
+                    replacement: `(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/${relativePathOfAssetFile}")`
+                });
             });
     }
 
     return { fixedJsCode };
+}
+
+function escapeRegExp(str: string) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceJsStringLiteral(params: {
+    code: string;
+    literal: string;
+    replacement: string;
+}) {
+    const { code, literal, replacement } = params;
+
+    const escapedLiteral = escapeRegExp(literal);
+
+    return code.replace(
+        new RegExp(
+            `(?:"${escapedLiteral}"|'${escapedLiteral}'|\`${escapedLiteral}\`)`,
+            "g"
+        ),
+        replacement
+    );
 }

--- a/test/bin/replacers.spec.ts
+++ b/test/bin/replacers.spec.ts
@@ -1,8 +1,8 @@
+import { replaceImportsInCssCode } from "keycloakify/bin/keycloakify/replacers/replaceImportsInCssCode";
 import { replaceImportsInJsCode_vite } from "keycloakify/bin/keycloakify/replacers/replaceImportsInJsCode/vite";
 import { replaceImportsInJsCode_webpack } from "keycloakify/bin/keycloakify/replacers/replaceImportsInJsCode/webpack";
-import { replaceImportsInCssCode } from "keycloakify/bin/keycloakify/replacers/replaceImportsInCssCode";
-import { expect, it, describe } from "vitest";
 import { WELL_KNOWN_DIRECTORY_BASE_NAME } from "keycloakify/bin/shared/constants";
+import { describe, expect, it } from "vitest";
 
 describe("js replacer - vite", () => {
     it("replaceImportsInJsCode_vite - 1", () => {
@@ -217,6 +217,240 @@ describe("js replacer - vite", () => {
                         return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
                     }
                 `;
+
+            expect(isSameCode(fixedJsCode, fixedJsCodeExpected)).toBe(true);
+        }
+    });
+
+    it("replaceImportsInJsCode_vite - 6", () => {
+        const jsCodeUntransformed = `
+            S=\`/assets/keycloakify-logo-mqjydaoZ.png\`,H=(()=>{
+
+            function __vite__mapDeps(indexes) {
+                if (!__vite__mapDeps.viteFileDeps) {
+                    __vite__mapDeps.viteFileDeps = [\`assets/Login-dJpPRzM4.js\`, \`assets/index-XwzrZ5Gu.js\`]
+                }
+                return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+            }
+        `;
+
+        for (const { projectBuildDirPath, assetsDirPath, systemType } of [
+            {
+                systemType: "posix",
+                projectBuildDirPath: "/Users/someone/github/keycloakify-starter/dist",
+                assetsDirPath: "/Users/someone/github/keycloakify-starter/dist/assets"
+            },
+            {
+                systemType: "win32",
+                projectBuildDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist",
+                assetsDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist\\assets"
+            }
+        ] as const) {
+            const { fixedJsCode } = replaceImportsInJsCode_vite({
+                jsCode: jsCodeUntransformed,
+                basenameOfAssetsFiles: [
+                    "Login-dJpPRzM4.js",
+                    "index-XwzrZ5Gu.js",
+                    "keycloakify-logo-mqjydaoZ.png"
+                ],
+                buildContext: {
+                    projectBuildDirPath,
+                    assetsDirPath,
+                    urlPathname: undefined
+                },
+                systemType
+            });
+
+            const fixedJsCodeExpected = `
+                S=(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/keycloakify-logo-mqjydaoZ.png"),H=(()=>{
+
+                function __vite__mapDeps(indexes) {
+                    if (!__vite__mapDeps.viteFileDeps) {
+                        __vite__mapDeps.viteFileDeps = [
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/Login-dJpPRzM4.js"),
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/index-XwzrZ5Gu.js")
+                        ]
+                    }
+                    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+                }
+            `;
+
+            expect(isSameCode(fixedJsCode, fixedJsCodeExpected)).toBe(true);
+        }
+    });
+    it("replaceImportsInJsCode_vite - 7", () => {
+        const jsCodeUntransformed = `
+            S=\`/foo-bar-baz/assets/keycloakify-logo-mqjydaoZ.png\`,H=(()=>{
+
+            function __vite__mapDeps(indexes) {
+                if (!__vite__mapDeps.viteFileDeps) {
+                    __vite__mapDeps.viteFileDeps = [\`assets/Login-dJpPRzM4.js\`, \`assets/index-XwzrZ5Gu.js\`]
+                }
+                return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+            }
+        `;
+
+        for (const { projectBuildDirPath, assetsDirPath, systemType } of [
+            {
+                systemType: "posix",
+                projectBuildDirPath: "/Users/someone/github/keycloakify-starter/dist",
+                assetsDirPath: "/Users/someone/github/keycloakify-starter/dist/assets"
+            },
+            {
+                systemType: "win32",
+                projectBuildDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist",
+                assetsDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist\\assets"
+            }
+        ] as const) {
+            const { fixedJsCode } = replaceImportsInJsCode_vite({
+                jsCode: jsCodeUntransformed,
+                basenameOfAssetsFiles: [
+                    "Login-dJpPRzM4.js",
+                    "index-XwzrZ5Gu.js",
+                    "keycloakify-logo-mqjydaoZ.png"
+                ],
+                buildContext: {
+                    projectBuildDirPath,
+                    assetsDirPath,
+                    urlPathname: "/foo-bar-baz/"
+                },
+                systemType
+            });
+
+            const fixedJsCodeExpected = `
+                S=(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/keycloakify-logo-mqjydaoZ.png"),H=(()=>{
+
+                function __vite__mapDeps(indexes) {
+                    if (!__vite__mapDeps.viteFileDeps) {
+                        __vite__mapDeps.viteFileDeps = [
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/Login-dJpPRzM4.js"),
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/index-XwzrZ5Gu.js")
+                        ]
+                    }
+                    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+                }
+            `;
+
+            expect(isSameCode(fixedJsCode, fixedJsCodeExpected)).toBe(true);
+        }
+    });
+    it("replaceImportsInJsCode_vite - 8", () => {
+        const jsCodeUntransformed = `
+            S='/assets/keycloakify-logo-mqjydaoZ.png',H=(()=>{
+
+            function __vite__mapDeps(indexes) {
+                if (!__vite__mapDeps.viteFileDeps) {
+                    __vite__mapDeps.viteFileDeps = ['assets/Login-dJpPRzM4.js', 'assets/index-XwzrZ5Gu.js']
+                }
+                return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+            }
+        `;
+
+        for (const { projectBuildDirPath, assetsDirPath, systemType } of [
+            {
+                systemType: "posix",
+                projectBuildDirPath: "/Users/someone/github/keycloakify-starter/dist",
+                assetsDirPath: "/Users/someone/github/keycloakify-starter/dist/assets"
+            },
+            {
+                systemType: "win32",
+                projectBuildDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist",
+                assetsDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist\\assets"
+            }
+        ] as const) {
+            const { fixedJsCode } = replaceImportsInJsCode_vite({
+                jsCode: jsCodeUntransformed,
+                basenameOfAssetsFiles: [
+                    "Login-dJpPRzM4.js",
+                    "index-XwzrZ5Gu.js",
+                    "keycloakify-logo-mqjydaoZ.png"
+                ],
+                buildContext: {
+                    projectBuildDirPath,
+                    assetsDirPath,
+                    urlPathname: undefined
+                },
+                systemType
+            });
+
+            const fixedJsCodeExpected = `
+                S=(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/keycloakify-logo-mqjydaoZ.png"),H=(()=>{
+
+                function __vite__mapDeps(indexes) {
+                    if (!__vite__mapDeps.viteFileDeps) {
+                        __vite__mapDeps.viteFileDeps = [
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/Login-dJpPRzM4.js"),
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/index-XwzrZ5Gu.js")
+                        ]
+                    }
+                    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+                }
+            `;
+
+            expect(isSameCode(fixedJsCode, fixedJsCodeExpected)).toBe(true);
+        }
+    });
+
+    it("replaceImportsInJsCode_vite - 9", () => {
+        const jsCodeUntransformed = `
+            S='/foo-bar-baz/assets/keycloakify-logo-mqjydaoZ.png',H=(()=>{
+
+            function __vite__mapDeps(indexes) {
+                if (!__vite__mapDeps.viteFileDeps) {
+                    __vite__mapDeps.viteFileDeps = ['assets/Login-dJpPRzM4.js', 'assets/index-XwzrZ5Gu.js']
+                }
+                return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+            }
+        `;
+
+        for (const { projectBuildDirPath, assetsDirPath, systemType } of [
+            {
+                systemType: "posix",
+                projectBuildDirPath: "/Users/someone/github/keycloakify-starter/dist",
+                assetsDirPath: "/Users/someone/github/keycloakify-starter/dist/assets"
+            },
+            {
+                systemType: "win32",
+                projectBuildDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist",
+                assetsDirPath:
+                    "C:\\\\Users\\someone\\github\\keycloakify-starter\\dist\\assets"
+            }
+        ] as const) {
+            const { fixedJsCode } = replaceImportsInJsCode_vite({
+                jsCode: jsCodeUntransformed,
+                basenameOfAssetsFiles: [
+                    "Login-dJpPRzM4.js",
+                    "index-XwzrZ5Gu.js",
+                    "keycloakify-logo-mqjydaoZ.png"
+                ],
+                buildContext: {
+                    projectBuildDirPath,
+                    assetsDirPath,
+                    urlPathname: "/foo-bar-baz/"
+                },
+                systemType
+            });
+
+            const fixedJsCodeExpected = `
+                S=(window.kcContext["x-keycloakify"].resourcesPath + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/keycloakify-logo-mqjydaoZ.png"),H=(()=>{
+
+                function __vite__mapDeps(indexes) {
+                    if (!__vite__mapDeps.viteFileDeps) {
+                        __vite__mapDeps.viteFileDeps = [
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/Login-dJpPRzM4.js"),
+                            (window.kcContext["x-keycloakify"].resourcesPath.substring(1) + "/${WELL_KNOWN_DIRECTORY_BASE_NAME.DIST}/assets/index-XwzrZ5Gu.js")
+                        ]
+                    }
+                    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+                }
+            `;
 
             expect(isSameCode(fixedJsCode, fixedJsCodeExpected)).toBe(true);
         }


### PR DESCRIPTION
Fixes a JS asset rewrite miss in the Vite Keycloakify build flow.

`replaceImportsInJsCode_vite` was only rewriting asset imports when Vite emitted them as double-quoted string literals, for example:

`"/assets/auth-logo-BR8ovgvV.svg"`
Starting with Vite 8, the generated JS can emit the same asset path as a template literal instead:

```  `/assets/auth-logo-BR8ovgvV.svg` ```
<img width="1679" height="1349" alt="image" src="https://github.com/user-attachments/assets/01a7d3e3-bdd1-4379-9d82-9bd56112c59e" />

When that happens, the rewrite step is skipped, so the generated Keycloak theme JS keeps /assets/... URLs instead of rewriting them to the Keycloak theme resources path.
<img width="2522" height="1439" alt="image" src="https://github.com/user-attachments/assets/48d23c04-4c84-42a7-9982-49b9c7e00462" />

This causes runtime-imported assets such as logos or SVG illustrations to 404 in Keycloak even though the files are bundled correctly in the theme JAR.

Example broken output:

```
src:n??`/assets/auth-logo-BR8ovgvV.svg`
var hu=`/assets/shape-DpIsiul3.svg`
```

In Keycloak, those assets need to resolve through:

`${window.kcContext["x-keycloakify"].resourcesPath}/dist/assets/...`

To fix that we need to xtend the Vite JS import replacer so it rewrites exact asset literals wrapped in any standard JS string delimiter:

- double quotes: "..."
- single quotes: '...'
- backticks: ``` `...` ```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved string-literal handling so asset URL rewrites work reliably across double quotes, single quotes, and backticks.
  * More robust handling of variations in asset path forms.

* **Tests**
  * Added new tests covering single-quote, backtick, and template-literal asset URL cases and different path variations to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->